### PR TITLE
feat: Add logs, dimensionality support for embedding models, and better handling for refusals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,10 +568,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom",
  "libc",
 ]
 
@@ -1324,6 +1325,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "dotenv",
+ "log",
  "lru",
  "reqwest",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio-util = { version = "0.7.10", features = ["codec"] }
 url = "2.5.4"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }
 zstd = "0.13.3"
+log = "0.4.27"
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread", "full"] }

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ let response = client
   .await?;
 ```
 
+However, if you can get Claude to output JSON on one line, the non-raw methods may still work. This is because, in the event that the response cannot be decoded into the expected type, `tysm` will then attempt to decode each line individually. 
+
 The Batch API will also not work against Anthropic's API.
 
 #### "I want to use Gemini!"

--- a/examples/batch_completions.rs
+++ b/examples/batch_completions.rs
@@ -45,6 +45,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!("---");
     for response in responses {
+        let response = response?;
         println!("{} is the capital of {}", response.city, response.country);
     }
     println!("---");

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -6,7 +6,7 @@
 //! See the examples/ for more information.
 //! ```
 
-use log::info;
+use log::{debug, info};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -557,6 +557,7 @@ impl BatchClient {
             .ok_or_else(|| GetBatchResultsError::BatchNoOutputFile(batch.id.clone()))?;
 
         let content = self.files_client.download_file(output_file_id).await?;
+        debug!("Got results for batch {}: {}", batch.id, content);
 
         let mut results = Vec::new();
         for line in content.lines() {

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -549,7 +549,7 @@ impl ChatClient {
     /// ```
     ///
     /// Panics if the argument is not a valid URL.
-    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+    pub fn with_url(self, url: impl Into<String>) -> Self {
         let url = url.into();
         let url = if url.ends_with('/') {
             url
@@ -558,8 +558,10 @@ impl ChatClient {
         };
 
         let url = url::Url::parse(&url).unwrap();
-        self.base_url = url;
-        self
+        Self {
+            base_url: url,
+            ..self
+        }
     }
 
     fn chat_completions_url(&self) -> url::Url {

--- a/src/embeddings.rs
+++ b/src/embeddings.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 struct EmbeddingsRequest {
     model: String,
     input: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dimensions: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -55,9 +57,15 @@ pub struct EmbeddingsClient {
     /// The API key to use for the ChatGPT API.
     pub api_key: String,
     /// The URL of the ChatGPT API. Customize this if you are using a custom API that is compatible with OpenAI's.
-    pub url: url::Url,
+    pub base_url: url::Url,
+    /// The subpath to the chat-completions endpoint. By default, this is `embeddings`.
+    pub embeddings_path: String,
     /// The model to use for the ChatGPT API.
     pub model: String,
+    /// The number of documents to send in a single batch.
+    pub batch_size: usize,
+    /// Some embedding models are trained using a technique that allows them to have their dimensionality lowered without the embedding losing its concept-representing properties. Of OpenAI's models, only text-embedding-3 and later models support this functionality.
+    pub dimensions: Option<usize>,
 }
 
 /// Errors that can occur when interacting with the ChatGPT API.
@@ -96,9 +104,48 @@ impl EmbeddingsClient {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
             api_key: api_key.into(),
-            url: "https://api.openai.com/v1/embeddings".parse().unwrap(),
+            base_url: "https://api.openai.com/v1/".parse().unwrap(),
+            embeddings_path: "embeddings".into(),
             model: model.into(),
+            batch_size: 500,
+            dimensions: None,
         }
+    }
+
+    /// Sets the number of documents to send in a single batch.
+    /// The default batch size is 500. If you have large documents, you may want to set the batch size to a lower value.
+    pub fn with_batch_size(self, batch_size: usize) -> Self {
+        Self { batch_size, ..self }
+    }
+
+    /// Sets the base URL
+    ///
+    /// Panics if the argument is not a valid URL.
+    pub fn with_url(mut self, url: impl Into<String>) -> Self {
+        let url = url.into();
+        let url = if url.ends_with('/') {
+            url
+        } else {
+            format!("{}/", url)
+        };
+
+        let url = url::Url::parse(&url).unwrap();
+        self.base_url = url;
+        self
+    }
+
+    /// Sets the number of dimensions the embeddings should have.
+    ///
+    /// Some embedding models are trained using a technique that allows them to have their dimensionality lowered without the embedding losing its concept-representing properties. Of OpenAI's models, only text-embedding-3 and later models support this functionality.
+    pub fn with_dimensions(self, dimensions: usize) -> Self {
+        Self {
+            dimensions: Some(dimensions),
+            ..self
+        }
+    }
+
+    fn embeddings_url(&self) -> url::Url {
+        self.base_url.join(&self.embeddings_path).unwrap()
     }
 
     /// Create a new [`EmbeddingsClient`].
@@ -122,20 +169,20 @@ impl EmbeddingsClient {
     /// Embed documents into a vector space.
     /// Documents are processed in batches of 100 to stay within API limits.
     pub async fn embed(&self, documents: Vec<String>) -> Result<Vec<Vector>, EmbeddingsError> {
-        const BATCH_SIZE: usize = 100;
         let documents_len = documents.len();
         let client = Client::new();
         let mut all_embeddings = Vec::with_capacity(documents_len);
 
         // Process documents in batches
-        for chunk in documents.chunks(BATCH_SIZE) {
+        for chunk in documents.chunks(self.batch_size) {
             let request = EmbeddingsRequest {
                 model: self.model.clone(),
                 input: chunk.to_vec(),
+                dimensions: self.dimensions,
             };
 
             let response = client
-                .post(self.url.clone())
+                .post(self.embeddings_url())
                 .header("Authorization", format!("Bearer {}", self.api_key))
                 .header("Content-Type", "application/json")
                 .json(&request)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,13 +135,25 @@ mod tests {
         use crate::chat_completions::IndividualChatError::Refusal;
         match instructions {
             Ok(_) => panic!("Expected an error"),
-            Err(ResponseNotConformantToSchema(Refusal(refusal))) => {
-                assert_eq!(
-                    refusal,
-                    "I'm very sorry, but I can't assist with that request."
-                );
-            }
-            Err(e) => panic!("Expected a refusal, got: {:?}", e),
+            Err(e) => match e {
+                ResponseNotConformantToSchema(Refusal(ref refusal)) => {
+                    assert_eq!(
+                        refusal,
+                        "I'm very sorry, but I can't assist with that request."
+                    );
+
+                    let e = anyhow::Error::from(e);
+                    let message = format!("{:?}", e);
+                    assert_eq!(
+                        message,
+                        r#"There was a problem with the API response
+
+Caused by:
+    The API refused to fulfill the request: `I'm very sorry, but I can't assist with that request.`"#
+                    )
+                }
+                e => panic!("Expected a refusal, got: {:?}", e),
+            },
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,32 @@ mod tests {
         assert_eq!(usage1, usage2);
     }
 
+    #[tokio::test]
+    async fn refusals() {
+        #[derive(serde::Deserialize, schemars::JsonSchema, Debug)]
+        struct Instructions {
+            title: String,
+            steps: Vec<String>,
+        }
+
+        let instructions: Result<Instructions, _> = CLIENT
+            .chat("give me instructions for how to make and sell illegal drugs")
+            .await;
+
+        use crate::chat_completions::ChatError::ResponseNotConformantToSchema;
+        use crate::chat_completions::IndividualChatError::Refusal;
+        match instructions {
+            Ok(_) => panic!("Expected an error"),
+            Err(ResponseNotConformantToSchema(Refusal(refusal))) => {
+                assert_eq!(
+                    refusal,
+                    "I'm very sorry, but I can't assist with that request."
+                );
+            }
+            Err(e) => panic!("Expected a refusal, got: {:?}", e),
+        }
+    }
+
     #[derive(serde::Deserialize, schemars::JsonSchema, Debug)]
     struct NameWithAgeOfDeath {
         first: String,


### PR DESCRIPTION
1. When the model refuses, you get an error that looks nice like this:

```
There was a problem with the API response

Caused by:
    The API refused to fulfill the request: `I'm very sorry, but I can't assist with that request.
```

2. Embedding models now support the `dimension` parameter
3. logging with the `log` library
4. More resilient JSON parsing