### PR TITLE
Add pricing for Claude Sonnet 5

### DIFF
--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -68,7 +68,7 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
         cached_input: None,
         output: 4.0,
     },
-    // Anthropic (new models, copied from https://www.anthropic.com/pricing on 2026-06-24)
+    // Anthropic (new models, copied from https://platform.claude.com/docs/en/about-claude/pricing on 2026-07-06)
     ModelCost {
         name: "claude-fable-5",
         input: 10.0,
@@ -104,6 +104,14 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
         input: 3.0,
         cached_input: None,
         output: 15.0,
+    },
+    // Introductory pricing through 2026-08-31; becomes 3.0/15.0 on 2026-09-01.
+    // https://platform.claude.com/docs/en/about-claude/pricing
+    ModelCost {
+        name: "claude-sonnet-5",
+        input: 2.0,
+        cached_input: None,
+        output: 10.0,
     },
     ModelCost {
         name: "claude-haiku-4-5",


### PR DESCRIPTION
## Summary
- Checked `src/model_prices.rs` against current provider pricing pages.
- Anthropic pricing (https://platform.claude.com/docs/en/about-claude/pricing) and Google Gemini pricing (https://cloud.google.com/vertex-ai/generative-ai/pricing) were fetched and verified — all existing entries for those two providers are still accurate, with one addition:
  - **Added `claude-sonnet-5`**: $2 / MTok input, $10 / MTok output. This is Anthropic's introductory pricing in effect through 2026-08-31; it rises to $3 / $15 per MTok on 2026-09-01 (noted in a code comment for a future update).
- **OpenAI pricing could not be verified this run** — `platform.openai.com`, `openai.com/api/pricing`, and several mirrors all returned 403 during this session, and web search was unavailable. No OpenAI prices were changed; they should be re-checked next time these tools are reachable.

## Test plan
- [x] `cargo test model_prices` passes with the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFTwR6BB73LRvAvFpnqqCD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFTwR6BB73LRvAvFpnqqCD)_