### PR TITLE
Update model costs

### DIFF
--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -292,6 +292,31 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
     },
     // GPT-5 models
     ModelCost {
+        // "gpt-5.6" alias routes to gpt-5.6-sol
+        name: "gpt-5.6",
+        input: 5.00,
+        cached_input: Some(0.50),
+        output: 30.00,
+    },
+    ModelCost {
+        name: "gpt-5.6-sol",
+        input: 5.00,
+        cached_input: Some(0.50),
+        output: 30.00,
+    },
+    ModelCost {
+        name: "gpt-5.6-terra",
+        input: 2.50,
+        cached_input: Some(0.25),
+        output: 15.00,
+    },
+    ModelCost {
+        name: "gpt-5.6-luna",
+        input: 1.00,
+        cached_input: Some(0.10),
+        output: 6.00,
+    },
+    ModelCost {
         name: "gpt-5.5-pro",
         input: 30.00,
         cached_input: None,

--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -239,25 +239,25 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
     ModelCost {
         name: "gemini-3.1-pro",
         input: 2.00,
-        cached_input: None,
+        cached_input: Some(0.20),
         output: 12.00,
     },
     ModelCost {
         name: "gemini-3-flash",
         input: 0.50,
-        cached_input: None,
+        cached_input: Some(0.05),
         output: 3.00,
     },
     ModelCost {
         name: "gemini-3.1-flash-lite",
         input: 0.25,
-        cached_input: None,
+        cached_input: Some(0.025),
         output: 1.50,
     },
     ModelCost {
         name: "gemini-3.5-flash",
         input: 1.50,
-        cached_input: None,
+        cached_input: Some(0.15),
         output: 9.00,
     },
     ModelCost {


### PR DESCRIPTION
## Summary

Checked the model pricing table in `src/model_prices.rs` against current provider documentation.

- **Anthropic (Claude):** no changes — all listed prices match current published rates.
- **OpenAI:** added the new **GPT-5.6** family (Sol, Terra, Luna), released July 9, 2026:
  - `gpt-5.6` (bare alias, routes to Sol): $5.00 input / $0.50 cached / $30.00 output per 1M tokens
  - `gpt-5.6-sol`: $5.00 / $0.50 cached / $30.00 (same price point as gpt-5.5)
  - `gpt-5.6-terra`: $2.50 / $0.25 cached / $15.00 (same price point as gpt-5.4)
  - `gpt-5.6-luna`: $1.00 / $0.10 cached / $6.00 (new lower-cost tier)

  All other OpenAI prices match current published rates.
- **Google Gemini:** four Gemini 3.x models were missing `cached_input` pricing (previously `None`). Added them at the standard ~10% of input-token rate (matching the pattern already used for the other Gemini entries in this file):
  - `gemini-3.1-pro`: cached input **$0.20**/1M tokens
  - `gemini-3-flash`: cached input **$0.05**/1M tokens
  - `gemini-3.1-flash-lite`: cached input **$0.025**/1M tokens
  - `gemini-3.5-flash`: cached input **$0.15**/1M tokens

### Sourcing note

Direct fetches of `platform.openai.com/docs/pricing`, `openai.com`, and `ai.google.dev/gemini-api/docs/pricing` were blocked by this environment's network policy, so pricing was cross-checked via search and secondary sources (multiple independent trackers/aggregators that agreed on the same GPT-5.6 figures, plus Google Cloud's Gemini Enterprise Agent Platform pricing page for the Gemini cached-input rates). The GPT-5.6 pricing/model-ID pattern was also confirmed by the user directly.

A few things surfaced during research that are **not** included in this PR because they couldn't be confirmed with high confidence:

- A possible discrepancy on `gpt-5.2-pro` pricing — the file's existing $21/$168 fits the established multiplier pattern from `gpt-5-pro` better than an unconfirmed $10.50/$84 figure found in one low-quality source, so it was left unchanged.
- Several already-deprecated/retired OpenAI models (`gpt-4o-audio-preview`, `gpt-4o-realtime-preview`, `gpt-4o-mini-audio-preview`, `gpt-4o-mini-realtime-preview`, `gpt-4.5-preview`) remain in the table for historical cost calculations; pricing for these is unchanged since they're no longer callable.

## Test plan
- [x] `cargo test model_prices` passes (4/4 tests)
- [x] Reviewed diff for scope
- [x] Verified the longest-prefix-match lookup still resolves `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` to their correct distinct rows

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
