### PR TITLE
Bump version to 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "tysm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tysm"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "Batteries-included Rust OpenAI Client"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump crate version from `0.19.0` to `0.19.1` in `Cargo.toml` (and regenerate `Cargo.lock` accordingly), to release the recent model-cost updates (#50).

## Test plan
- [x] `cargo check` passes with the new version

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01KKWe2YaUg9Gckw8Upgyby6)_