### PR TITLE
Update model costs

### DIFF
--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -82,6 +82,12 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
         output: 50.0,
     },
     ModelCost {
+        name: "claude-opus-5",
+        input: 5.0,
+        cached_input: None,
+        output: 25.0,
+    },
+    ModelCost {
         name: "claude-opus-4-8",
         input: 5.0,
         cached_input: None,
@@ -259,6 +265,19 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
         input: 1.50,
         cached_input: Some(0.15),
         output: 9.00,
+    },
+    // Released 2026-07-21 (google blog: gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber)
+    ModelCost {
+        name: "gemini-3.6-flash",
+        input: 1.50,
+        cached_input: Some(0.15),
+        output: 7.50,
+    },
+    ModelCost {
+        name: "gemini-3.5-flash-lite",
+        input: 0.30,
+        cached_input: Some(0.03),
+        output: 2.50,
     },
     ModelCost {
         name: "gemini-2.5-pro",


### PR DESCRIPTION
## Summary

- Add missing `claude-opus-5` pricing ($5.00 / $25.00 per 1M input/output tokens, same rate as Opus 4.8). This model had no entry at all, so `cost()` silently returned `None` for it despite it being a current, generally-available model.
- Add `gemini-3.6-flash` ($1.50 / $0.15 cached / $7.50) and `gemini-3.5-flash-lite` ($0.30 / $0.03 cached / $2.50) — new Google models released 2026-07-21.
- Anthropic (aside from the `claude-opus-5` gap) and OpenAI pricing were checked against current sources and found unchanged since the last update (#50).

Note: Google also released a `gemini-3.5-flash-cyber` model on the same date, but it's a restricted-access security model with no published per-token API pricing, so it isn't included here.

## Test plan

- [x] `cargo test model_prices --lib` passes (4/4)
- [x] Verified `claude-opus-5` was absent via `grep` before adding it
- [x] Cross-checked new Gemini pricing across multiple independent sources (TechCrunch, Axios, Google's own blog post, WinBuzzer, SecurityAffairs)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WhhGTHqjy9KX6w6yGqDEHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhhGTHqjy9KX6w6yGqDEHQ)_