### PR TITLE
Update model costs (OpenAI GPT-5.6 Terra/Luna price cut)

### DIFF
--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -323,17 +323,19 @@ pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
         cached_input: Some(0.50),
         output: 30.00,
     },
+    // Cut 20% on 2026-07-30 (from 2.50/0.25/15.00); https://openai.com/pricing
     ModelCost {
         name: "gpt-5.6-terra",
-        input: 2.50,
-        cached_input: Some(0.25),
-        output: 15.00,
+        input: 2.00,
+        cached_input: Some(0.20),
+        output: 12.00,
     },
+    // Cut 80% on 2026-07-30 (from 1.00/0.10/6.00); https://openai.com/pricing
     ModelCost {
         name: "gpt-5.6-luna",
-        input: 1.00,
-        cached_input: Some(0.10),
-        output: 6.00,
+        input: 0.20,
+        cached_input: Some(0.02),
+        output: 1.20,
     },
     ModelCost {
         name: "gpt-5.5-pro",


### PR DESCRIPTION
## Summary
- OpenAI cut GPT-5.6 Terra pricing 20% and GPT-5.6 Luna pricing 80% on 2026-07-30 — a change that predates but wasn't caught by the previous day's pricing check (#52):
  - `gpt-5.6-terra`: $2.50 / $0.25 cached / $15.00 → **$2.00 / $0.20 cached / $12.00**
  - `gpt-5.6-luna`: $1.00 / $0.10 cached / $6.00 → **$0.20 / $0.02 cached / $1.20**
- `gpt-5.6-sol` is unchanged.
- Verified: Anthropic pricing (including the `claude-sonnet-5` introductory rate, still active through 2026-08-31) and Google Gemini pricing are unchanged since the last update — checked against current sources.

## Test plan
- [x] `cargo test model_prices` passes

Claude-Session: https://claude.ai/code/session_0129z52ohxk3g8dhXVcwBBaD

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0129z52ohxk3g8dhXVcwBBaD)_