### PR TITLE
Track Batch API token usage and include it in cost() at half price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "model-prices"
+version = "0.1.0"
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1374,7 @@ dependencies = [
  "itertools",
  "log",
  "lru",
+ "model-prices",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "tysm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["model-prices"]
 
 [package]
 name = "tysm"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Batteries-included Rust OpenAI Client"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22.1"
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread", "full"] }
 tokio-test = "0.4"
 anyhow = "1"
+tempfile = "3"
 
 [[example]]
 name = "chat-completions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["model-prices"]
+
 [package]
 name = "tysm"
 version = "0.20.0"
@@ -19,6 +22,7 @@ keywords = [
 default = ["dotenvy"]
 
 [dependencies]
+model-prices = { path = "model-prices", version = "0.1.0" }
 dotenvy = { version = "0.15.0", optional = true }
 reqwest = { version = "0.11.20", features = ["json", "multipart", "stream"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/batch_completions.rs
+++ b/examples/batch_completions.rs
@@ -40,6 +40,15 @@ async fn main() -> anyhow::Result<()> {
         .batch_chat_with_system_prompt::<Response>(
             "Respond in JSON format with the city and country.",
             requests,
+            |batch| {
+                println!(
+                    "Batch progress: {}/{} completed, {} failed ({})",
+                    batch.request_counts.completed,
+                    batch.request_counts.total,
+                    batch.request_counts.failed,
+                    batch.status
+                );
+            },
         )
         .await?;
 

--- a/examples/batch_completions_low_level.rs
+++ b/examples/batch_completions_low_level.rs
@@ -98,7 +98,17 @@ async fn main() -> anyhow::Result<()> {
     // Wait for batch to complete
     println!("Waiting for batch to complete...");
     println!("(This may take a while, up to 24 hours)");
-    let completed_batch = batch_client.wait_for_batch(&batch.id).await?;
+    let completed_batch = batch_client
+        .wait_for_batch(&batch.id, |batch| {
+            println!(
+                "Batch progress: {}/{} completed, {} failed ({})",
+                batch.request_counts.completed,
+                batch.request_counts.total,
+                batch.request_counts.failed,
+                batch.status
+            );
+        })
+        .await?;
     println!("Batch completed!");
 
     // Get batch results

--- a/model-prices/Cargo.toml
+++ b/model-prices/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "model-prices"
+version = "0.1.0"
+edition = "2021"
+description = "Published per-token prices for hosted LLMs, as plain data"
+license = "MIT"
+homepage = "https://github.com/not-pizza/tysm"
+repository = "https://github.com/not-pizza/tysm"
+keywords = ["openai", "anthropic", "gemini", "pricing", "llm"]
+
+# Intentionally empty, and worth keeping that way: this crate is vendored into
+# builds (Android/Soong among them) that would otherwise have to vendor a
+# dependency tree alongside it just to multiply tokens by a rate.
+[dependencies]

--- a/model-prices/src/lib.rs
+++ b/model-prices/src/lib.rs
@@ -1,0 +1,530 @@
+//! The published per-token prices of hosted LLMs, as plain data.
+//!
+//! Rates are USD per million tokens, copied from each vendor's published
+//! pricing page. The comment above a block records which page, and when.
+//!
+//! Three things make a model's price more than a single pair of numbers:
+//!
+//! * **Cached input.** Most vendors discount prompt tokens they served from
+//!   their own cache.
+//! * **Service tier.** OpenAI sells the same model at `flex` (cheaper, slower)
+//!   and `priority` (dearer, faster) beside the standard rate.
+//! * **Prompt size.** Some models re-price the *whole request* once its prompt
+//!   crosses a threshold — see [`LongContext`].
+//!
+//! This crate deliberately has no dependencies — not even on a client library's
+//! usage type — so that anything needing to price tokens can vendor it alone.
+
+/// One request's billable token counts.
+///
+/// A named struct rather than three positional integers because the three are
+/// the same type, and swapping cached for output silently mis-bills instead of
+/// failing to compile.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CallTokens {
+    /// Prompt tokens, cached ones included.
+    pub prompt: u32,
+    /// Prompt tokens the vendor served from cache — a subset of `prompt`,
+    /// billed at the cheaper cached rate.
+    pub cached_prompt: u32,
+    /// Generated tokens, reasoning included. Vendors that report reasoning
+    /// separately from completion must add the two before setting this, since
+    /// both are billed at the output rate.
+    pub output: u32,
+}
+
+/// USD per million tokens at one service tier.
+#[derive(Debug, Clone, Copy)]
+pub struct TierCost {
+    /// The cost of uncached input tokens.
+    pub input: f64,
+    /// The cost of input tokens the vendor served from cache. `None` when the
+    /// vendor publishes no cache discount, in which case cached tokens are
+    /// billed at `input`.
+    pub cached_input: Option<f64>,
+    /// The cost of output tokens.
+    pub output: f64,
+}
+
+impl TierCost {
+    /// Bill one request's tokens at these rates, keeping the input and output
+    /// halves apart.
+    fn charge_split(&self, uncached_input: u32, cached_input: u32, output: u32) -> (f64, f64) {
+        let cached_rate = self.cached_input.unwrap_or(self.input);
+        let input =
+            (self.input * uncached_input as f64 + cached_rate * cached_input as f64) / 1_000_000.0;
+        (input, self.output * output as f64 / 1_000_000.0)
+    }
+}
+
+/// The rates that replace a model's whole card once a single request's prompt
+/// exceeds `above_prompt_tokens`.
+///
+/// The premium applies to the *entire* request, not merely the tokens past the
+/// threshold. That is why cost must be computed per call and the dollars
+/// summed — summing tokens across calls and pricing the total would push an
+/// innocent series of short requests over the threshold and bill every one of
+/// them at the premium.
+#[derive(Debug, Clone, Copy)]
+pub struct LongContext {
+    /// The prompt size above which this card replaces the standard one. A
+    /// prompt exactly this large is still billed at the cheaper card.
+    pub above_prompt_tokens: u32,
+    /// The standard-tier rates above the threshold.
+    pub standard: TierCost,
+    /// As [`ModelCost::flex`], above the threshold.
+    pub flex: Option<TierCost>,
+    /// As [`ModelCost::priority`], above the threshold.
+    pub priority: Option<TierCost>,
+}
+
+/// Everything we know about one model's price.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelCost {
+    /// Matched as a prefix of the requested model, longest match winning, so
+    /// that a dated id like `gpt-5.6-terra-2026-06-01` resolves to the entry
+    /// for `gpt-5.6-terra`.
+    pub name: &'static str,
+    /// The rates everyone pays unless they ask for another tier.
+    pub standard: TierCost,
+    /// `None` means the vendor does not sell this model at that tier, and a
+    /// request asking for it is billed at `standard`.
+    pub flex: Option<TierCost>,
+    /// As `flex`.
+    pub priority: Option<TierCost>,
+    /// `None` means this model costs the same whatever the prompt size.
+    pub long_context: Option<LongContext>,
+}
+
+impl ModelCost {
+    /// The rates for one request: the long-context card if the prompt crosses
+    /// this model's threshold, and within that the requested tier if the
+    /// vendor sells one.
+    fn rates(&self, service_tier: Option<&str>, prompt_tokens: u32) -> &TierCost {
+        let (standard, flex, priority) = match &self.long_context {
+            Some(long) if prompt_tokens > long.above_prompt_tokens => {
+                (&long.standard, &long.flex, &long.priority)
+            }
+            _ => (&self.standard, &self.flex, &self.priority),
+        };
+        match service_tier {
+            Some("flex") => flex.as_ref().unwrap_or(standard),
+            Some("priority") => priority.as_ref().unwrap_or(standard),
+            _ => standard,
+        }
+    }
+
+    const fn flex(mut self, input: f64, cached_input: Option<f64>, output: f64) -> Self {
+        self.flex = Some(TierCost {
+            input,
+            cached_input,
+            output,
+        });
+        self
+    }
+
+    const fn priority(mut self, input: f64, cached_input: Option<f64>, output: f64) -> Self {
+        self.priority = Some(TierCost {
+            input,
+            cached_input,
+            output,
+        });
+        self
+    }
+
+    const fn long_context(mut self, long: LongContext) -> Self {
+        self.long_context = Some(long);
+        self
+    }
+}
+
+impl LongContext {
+    const fn flex(mut self, input: f64, cached_input: Option<f64>, output: f64) -> Self {
+        self.flex = Some(TierCost {
+            input,
+            cached_input,
+            output,
+        });
+        self
+    }
+
+    const fn priority(mut self, input: f64, cached_input: Option<f64>, output: f64) -> Self {
+        self.priority = Some(TierCost {
+            input,
+            cached_input,
+            output,
+        });
+        self
+    }
+}
+
+/// One model at its standard rates. Chain `.flex()`, `.priority()`, and
+/// `.long_context()` onto it for the models that need them.
+const fn model(
+    name: &'static str,
+    input: f64,
+    cached_input: Option<f64>,
+    output: f64,
+) -> ModelCost {
+    ModelCost {
+        name,
+        standard: TierCost {
+            input,
+            cached_input,
+            output,
+        },
+        flex: None,
+        priority: None,
+        long_context: None,
+    }
+}
+
+/// The standard-tier rates above `above_prompt_tokens`. Chain `.flex()` and
+/// `.priority()` for the tiers the vendor also re-prices.
+const fn long(
+    above_prompt_tokens: u32,
+    input: f64,
+    cached_input: Option<f64>,
+    output: f64,
+) -> LongContext {
+    LongContext {
+        above_prompt_tokens,
+        standard: TierCost {
+            input,
+            cached_input,
+            output,
+        },
+        flex: None,
+        priority: None,
+    }
+}
+
+/// The prompt size above which the gpt-5.x family charges its long-context
+/// premium. OpenAI publishes the boundary only for gpt-5.5 ("<272K context
+/// length"); the rest of the family is assumed to share it.
+const GPT_5_LONG_CONTEXT: u32 = 272_000;
+
+/// Every model we know a price for.
+///
+/// One entry per model, carrying all of its tiers — so changing a price is a
+/// single local edit, and a tier the vendor sells but we have not filled in is
+/// visible as a missing `.flex()` rather than hidden in a second table.
+pub const MODELS: &[ModelCost] = &[
+    // Anthropic
+    model("claude-opus-4.5", 5.0, None, 25.0),
+    model("claude-opus-4.1", 15.0, None, 75.0),
+    model("claude-opus-4", 15.0, None, 75.0),
+    model("claude-sonnet-4.5", 3.0, None, 15.0),
+    model("claude-sonnet-4", 3.0, None, 15.0),
+    model("claude-haiku-4", 0.80, None, 4.0),
+    model("claude-3-opus", 15.0, None, 75.0),
+    model("claude-3-7-sonnet", 3.0, None, 15.0),
+    model("claude-3-5-haiku", 0.80, None, 4.0),
+    // Anthropic (new models, copied from https://platform.claude.com/docs/en/about-claude/pricing on 2026-07-06)
+    model("claude-fable-5", 10.0, None, 50.0),
+    model("claude-mythos-5", 10.0, None, 50.0),
+    model("claude-opus-5", 5.0, None, 25.0),
+    model("claude-opus-4-8", 5.0, None, 25.0),
+    model("claude-opus-4-7", 5.0, None, 25.0),
+    model("claude-opus-4-6", 5.0, None, 25.0),
+    model("claude-sonnet-4-6", 3.0, None, 15.0),
+    // Introductory pricing through 2026-08-31; becomes 3.0/15.0 on 2026-09-01.
+    // https://platform.claude.com/docs/en/about-claude/pricing
+    model("claude-sonnet-5", 2.0, None, 10.0),
+    model("claude-haiku-4-5", 1.0, None, 5.0),
+    // OpenAI
+    // Copied from https://platform.openai.com/docs/pricing on 2026-03-17
+    model("gpt-4.1", 2.00, Some(0.50), 8.00),
+    model("gpt-4.1-mini", 0.40, Some(0.10), 1.60),
+    model("gpt-4.1-nano", 0.10, Some(0.025), 0.40),
+    model("gpt-4.5-preview", 75.00, Some(37.50), 150.00),
+    model("gpt-4o", 2.50, Some(1.25), 10.00),
+    model("gpt-4o-audio-preview", 2.50, None, 10.00),
+    model("gpt-4o-realtime-preview", 5.00, Some(2.50), 20.00),
+    model("gpt-4o-mini", 0.15, Some(0.075), 0.60),
+    model("gpt-4o-mini-audio-preview", 0.15, None, 0.60),
+    model("gpt-4o-mini-realtime-preview", 0.60, Some(0.30), 2.40),
+    model("o1", 15.00, Some(7.50), 60.00),
+    model("o1-pro", 150.00, None, 600.00),
+    model("o3", 2.00, Some(0.50), 8.00).flex(1.00, Some(0.25), 4.00),
+    model("o4-mini", 1.10, Some(0.275), 4.40).flex(0.55, Some(0.138), 2.20),
+    model("o3-mini", 1.10, Some(0.55), 4.40),
+    model("o1-mini", 1.10, Some(0.55), 4.40),
+    model("gpt-4o-mini-search-preview", 0.15, None, 0.60),
+    model("gpt-4o-search-preview", 2.50, None, 10.00),
+    model("computer-use-preview", 3.00, None, 12.00),
+    // Google Gemini
+    //
+    // Gemini sells the same tiers OpenAI does, and the cheap one carries most
+    // background traffic, so leaving it out would bill the common case at
+    // twice its rate. Flex is Google's published half-price tier (the batch
+    // rate, where that is the only cheap rate published); priority follows the
+    // family's 1.8x convention, which Google does not state for every model.
+    //
+    // Pro is the one Gemini family Google prices by prompt size: every column
+    // roughly doubles above 200k.
+    model("gemini-3.1-pro", 2.00, Some(0.20), 12.00)
+        .flex(1.00, Some(0.20), 6.00)
+        .priority(3.60, Some(0.36), 21.60)
+        .long_context(
+            long(200_000, 4.00, Some(0.40), 18.00)
+                .flex(2.00, Some(0.40), 9.00)
+                .priority(7.20, Some(0.72), 32.40),
+        ),
+    model("gemini-3-flash", 0.50, Some(0.05), 3.00)
+        .flex(0.25, Some(0.05), 1.50)
+        .priority(0.90, Some(0.09), 5.40),
+    model("gemini-3.1-flash-lite", 0.25, Some(0.025), 1.50)
+        .flex(0.125, Some(0.0125), 0.75)
+        .priority(0.45, Some(0.045), 2.70),
+    model("gemini-3.5-flash", 1.50, Some(0.15), 9.00)
+        .flex(0.75, Some(0.08), 4.50)
+        .priority(2.70, Some(0.27), 16.20),
+    // Released 2026-07-21 (google blog: gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber)
+    model("gemini-3.6-flash", 1.50, Some(0.15), 7.50)
+        .flex(0.75, Some(0.075), 3.75)
+        .priority(2.70, Some(0.27), 13.50),
+    model("gemini-3.5-flash-lite", 0.30, Some(0.03), 2.50)
+        .flex(0.15, Some(0.015), 1.25)
+        .priority(0.54, Some(0.054), 4.50),
+    model("gemini-2.5-pro", 1.25, Some(0.125), 10.00)
+        .flex(0.625, Some(0.125), 5.00)
+        .priority(2.25, Some(0.225), 18.00)
+        .long_context(
+            long(200_000, 2.50, Some(0.25), 15.00)
+                .flex(1.25, Some(0.25), 7.50)
+                .priority(4.50, Some(0.45), 27.00),
+        ),
+    model("gemini-2.5-flash", 0.30, Some(0.03), 2.50)
+        .flex(0.15, Some(0.03), 1.25)
+        .priority(0.54, Some(0.054), 4.50),
+    model("gemini-2.5-flash-lite", 0.10, Some(0.01), 0.40)
+        .flex(0.05, Some(0.01), 0.20)
+        .priority(0.18, Some(0.018), 0.72),
+    model("gemini-2.0-flash", 0.15, None, 0.60),
+    model("gemini-2.0-flash-lite", 0.075, None, 0.30),
+    // GPT-5 models
+    //
+    // Every gpt-5.x model charges a long-context premium, but the rates above
+    // the threshold are filled in below only for the gpt-5.6 family. The
+    // others are known to carry a premium we have not recorded, and so
+    // under-bill requests with prompts over `GPT_5_LONG_CONTEXT`.
+    // "gpt-5.6" alias routes to gpt-5.6-sol
+    model("gpt-5.6", 5.00, Some(0.50), 30.00)
+        .flex(2.50, Some(0.25), 15.00)
+        .priority(10.00, Some(1.00), 60.00)
+        .long_context(
+            long(GPT_5_LONG_CONTEXT, 10.00, Some(1.00), 45.00)
+                .flex(5.00, Some(0.50), 22.50)
+                .priority(20.00, Some(2.00), 90.00),
+        ),
+    model("gpt-5.6-sol", 5.00, Some(0.50), 30.00)
+        .flex(2.50, Some(0.25), 15.00)
+        .priority(10.00, Some(1.00), 60.00)
+        .long_context(
+            long(GPT_5_LONG_CONTEXT, 10.00, Some(1.00), 45.00)
+                .flex(5.00, Some(0.50), 22.50)
+                .priority(20.00, Some(2.00), 90.00),
+        ),
+    // Cut 20% on 2026-07-30 (from 2.50/0.25/15.00); https://openai.com/pricing
+    model("gpt-5.6-terra", 2.00, Some(0.20), 12.00)
+        .flex(1.00, Some(0.10), 6.00)
+        .priority(4.00, Some(0.40), 24.00)
+        .long_context(
+            long(GPT_5_LONG_CONTEXT, 4.00, Some(0.40), 18.00)
+                .flex(2.00, Some(0.20), 9.00)
+                .priority(8.00, Some(0.80), 36.00),
+        ),
+    // Cut 80% on 2026-07-30 (from 1.00/0.10/6.00); https://openai.com/pricing
+    model("gpt-5.6-luna", 0.20, Some(0.02), 1.20)
+        .flex(0.10, Some(0.01), 0.60)
+        .priority(0.40, Some(0.04), 2.40)
+        .long_context(
+            long(GPT_5_LONG_CONTEXT, 0.40, Some(0.04), 1.80)
+                .flex(0.20, Some(0.02), 0.90)
+                .priority(0.80, Some(0.08), 3.60),
+        ),
+    model("gpt-5.5-pro", 30.00, None, 180.00),
+    model("gpt-5.5", 5.00, Some(0.50), 30.00)
+        .flex(2.50, Some(0.25), 15.00)
+        .priority(12.50, Some(1.25), 75.00),
+    model("gpt-5.4-pro", 30.00, None, 180.00).flex(15.00, None, 90.00),
+    model("gpt-5.4", 2.50, Some(0.25), 15.00)
+        .flex(1.25, Some(0.13), 7.50)
+        .priority(5.00, Some(0.50), 30.00),
+    model("gpt-5.4-mini", 0.75, Some(0.075), 4.50).flex(0.375, Some(0.0375), 2.25),
+    model("gpt-5.4-nano", 0.20, Some(0.02), 1.25).flex(0.10, Some(0.01), 0.625),
+    model("gpt-5.2-chat-latest", 1.75, Some(0.175), 14.00),
+    model("gpt-5.2-pro", 21.00, None, 168.00),
+    model("gpt-5.2", 1.75, Some(0.175), 14.00).flex(0.875, Some(0.0875), 7.00),
+    model("gpt-5.1-chat-latest", 1.25, Some(0.125), 10.00),
+    model("gpt-5.1-codex-max", 1.25, Some(0.125), 10.00),
+    model("gpt-5.1-codex", 1.25, Some(0.125), 10.00),
+    model("gpt-5.1", 1.25, Some(0.125), 10.00).flex(0.625, Some(0.0625), 5.00),
+    model("gpt-5-chat-latest", 1.25, Some(0.125), 10.00),
+    model("gpt-5-codex", 1.25, Some(0.125), 10.00),
+    model("gpt-5-pro", 15.00, None, 120.00),
+    model("gpt-5-mini", 0.25, Some(0.025), 2.00).flex(0.125, Some(0.0125), 1.00),
+    model("gpt-5-nano", 0.05, Some(0.005), 0.40).flex(0.025, Some(0.0025), 0.20),
+    model("gpt-5", 1.25, Some(0.125), 10.00).flex(0.625, Some(0.0625), 5.00),
+];
+
+/// The entry that prices `model`, or `None` if we have no price for it.
+///
+/// Callers that only want a dollar figure should use [`cost_of_call`]; this is
+/// for inspecting the rates themselves, or asking whether a model is priced at
+/// all before recording a cost against it.
+pub fn price_of(model: &str) -> Option<&'static ModelCost> {
+    MODELS
+        .iter()
+        .filter(|mc| model.starts_with(mc.name))
+        .max_by_key(|mc| mc.name.len())
+}
+
+/// When this table was last checked against the vendors' pricing pages.
+///
+/// Stamp it onto anything that records a dollar figure, so historical token
+/// counts can be repriced when a vendor moves its list prices. Bump it
+/// whenever a rate in [`MODELS`] changes.
+pub const RATE_CARD_VERSION: &str = "2026-07-30";
+
+/// The cost in dollars of a **single** request.
+///
+/// Must be called once per request and the results summed. Summing the token
+/// counts of several requests and pricing the total gives a different — and
+/// wrong — answer for any model with a [`LongContext`] card, because the
+/// premium keys off one request's prompt size.
+///
+/// Returns `None` for a model we have no price for.
+pub fn cost_of_call(model: &str, service_tier: Option<&str>, tokens: CallTokens) -> Option<f64> {
+    cost_of_call_split(model, service_tier, tokens).map(|(input, output)| input + output)
+}
+
+/// As [`cost_of_call`], but keeping the input and output dollars apart — for
+/// callers that report the two separately rather than only the total.
+pub fn cost_of_call_split(
+    model: &str,
+    service_tier: Option<&str>,
+    tokens: CallTokens,
+) -> Option<(f64, f64)> {
+    let model_cost = price_of(model)?;
+
+    let cached = tokens.cached_prompt.min(tokens.prompt);
+    let uncached = tokens.prompt - cached;
+
+    Some(model_cost.rates(service_tier, tokens.prompt).charge_split(
+        uncached,
+        cached,
+        tokens.output,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage(prompt: u32, cached_prompt: u32, output: u32) -> CallTokens {
+        CallTokens {
+            prompt,
+            cached_prompt,
+            output,
+        }
+    }
+
+    #[test]
+    fn test_cost() {
+        // input: 2.50, cached_input: Some(1.25), output: 10.00
+        let cost = cost_of_call("gpt-4o", None, usage(2_000_000, 1_000_000, 1_000_000));
+        assert_eq!(cost, Some(2.50 + 1.25 + 10.00));
+    }
+
+    #[test]
+    fn test_flex_cost() {
+        // gpt-5.4 flex: input 1.25, output 7.50
+        let c = cost_of_call("gpt-5.4", Some("flex"), usage(1_000_000, 0, 1_000_000));
+        assert_eq!(c, Some(1.25 + 7.50));
+    }
+
+    #[test]
+    fn test_priority_cost() {
+        // gpt-5.4 priority: input 5.00, output 30.00
+        let c = cost_of_call("gpt-5.4", Some("priority"), usage(1_000_000, 0, 1_000_000));
+        assert_eq!(c, Some(5.00 + 30.00));
+    }
+
+    #[test]
+    fn test_tier_falls_back_to_standard() {
+        // gpt-4o has no flex pricing, should fall back to standard
+        let u = usage(1_000_000, 0, 1_000_000);
+        assert_eq!(
+            cost_of_call("gpt-4o", None, u),
+            cost_of_call("gpt-4o", Some("flex"), u)
+        );
+    }
+
+    #[test]
+    fn unknown_model_has_no_price() {
+        assert_eq!(
+            cost_of_call("no-such-model", None, usage(1_000, 0, 1_000)),
+            None
+        );
+    }
+
+    /// A dated model id bills at its family's rates rather than falling off
+    /// the table, and the longest matching name wins over a shorter prefix.
+    #[test]
+    fn dated_ids_resolve_to_the_longest_matching_prefix() {
+        let u = usage(1_000_000, 0, 0);
+        assert_eq!(
+            cost_of_call("gpt-5.6-terra-2026-06-01", None, u),
+            cost_of_call("gpt-5.6-terra", None, u),
+        );
+        // ...and not to the shorter "gpt-5.6" alias, which is priced as sol.
+        assert_ne!(
+            cost_of_call("gpt-5.6-terra", None, u),
+            cost_of_call("gpt-5.6", None, u),
+        );
+    }
+
+    /// The premium re-prices the entire request, and a prompt exactly at the
+    /// threshold is still billed at the cheaper card.
+    #[test]
+    fn long_prompts_bill_the_whole_request_at_the_premium() {
+        // 200k exactly: 0.2M @ $2.00 = $0.40.
+        let at_threshold = cost_of_call("gemini-3.1-pro", None, usage(200_000, 0, 0)).unwrap();
+        assert!((at_threshold - 0.40).abs() < 1e-9, "{at_threshold}");
+
+        // One token over flips the whole request to $4.00/M, so ~2x — not a
+        // surcharge on the single token past the line.
+        let over = cost_of_call("gemini-3.1-pro", None, usage(200_001, 0, 0)).unwrap();
+        assert!((over - 0.800004).abs() < 1e-9, "{over}");
+    }
+
+    /// The long-context card has tiers of its own; asking for flex above the
+    /// threshold must not fall back to the standard long-context rate.
+    #[test]
+    fn long_context_has_its_own_tiers() {
+        let u = usage(300_000, 0, 0);
+        let standard = cost_of_call("gpt-5.6-luna", None, u).unwrap();
+        let flex = cost_of_call("gpt-5.6-luna", Some("flex"), u).unwrap();
+        // 0.3M @ $0.40 standard, @ $0.20 flex.
+        assert!((standard - 0.12).abs() < 1e-9, "{standard}");
+        assert!((flex - 0.06).abs() < 1e-9, "{flex}");
+    }
+
+    /// Pricing each call and summing is not the same as summing tokens and
+    /// pricing once — the reason [`cost_of_call`] is per-request.
+    #[test]
+    fn summing_tokens_would_overbill_short_calls() {
+        // Six 50k-token calls: each is well under the threshold, so each bills
+        // at the cheap card even though they sum to 300k.
+        let per_call = cost_of_call("gpt-5.6-luna", None, usage(50_000, 0, 0)).unwrap();
+        let summed_correctly = per_call * 6.0;
+        let priced_as_one_lump = cost_of_call("gpt-5.6-luna", None, usage(300_000, 0, 0)).unwrap();
+        assert!((summed_correctly - 0.06).abs() < 1e-9, "{summed_correctly}");
+        assert!(
+            (priced_as_one_lump - 0.12).abs() < 1e-9,
+            "{priced_as_one_lump}"
+        );
+    }
+}

--- a/model-prices/src/lib.rs
+++ b/model-prices/src/lib.rs
@@ -211,10 +211,18 @@ const GPT_5_LONG_CONTEXT: u32 = 272_000;
 /// visible as a missing `.flex()` rather than hidden in a second table.
 pub const MODELS: &[ModelCost] = &[
     // Anthropic
+    //
+    // Both spellings of a point release are listed. The API's own ids use
+    // dashes (`claude-opus-4-5-20251101`), and with only the dotted spelling
+    // present the longest-prefix match falls back to the major version —
+    // billing Opus 4.5 at Opus 4's $15/$75 instead of $5/$25.
     model("claude-opus-4.5", 5.0, None, 25.0),
+    model("claude-opus-4-5", 5.0, None, 25.0),
     model("claude-opus-4.1", 15.0, None, 75.0),
+    model("claude-opus-4-1", 15.0, None, 75.0),
     model("claude-opus-4", 15.0, None, 75.0),
     model("claude-sonnet-4.5", 3.0, None, 15.0),
+    model("claude-sonnet-4-5", 3.0, None, 15.0),
     model("claude-sonnet-4", 3.0, None, 15.0),
     model("claude-haiku-4", 0.80, None, 4.0),
     model("claude-3-opus", 15.0, None, 75.0),
@@ -305,10 +313,12 @@ pub const MODELS: &[ModelCost] = &[
     model("gemini-2.0-flash-lite", 0.075, None, 0.30),
     // GPT-5 models
     //
-    // Every gpt-5.x model charges a long-context premium, but the rates above
-    // the threshold are filled in below only for the gpt-5.6 family. The
-    // others are known to carry a premium we have not recorded, and so
-    // under-bill requests with prompts over `GPT_5_LONG_CONTEXT`.
+    // Only the 5.6 family carries a `long_context` card here, because those
+    // are the rates we have. OpenAI states the 272k boundary for gpt-5.5 but
+    // we have not recorded what it charges past it, and whether the older
+    // 5.x models tier by prompt size at all is unconfirmed — so a long
+    // request on any of them bills at the short card. Filling these in is the
+    // first thing to check when refreshing this table.
     // "gpt-5.6" alias routes to gpt-5.6-sol
     model("gpt-5.6", 5.00, Some(0.50), 30.00)
         .flex(2.50, Some(0.25), 15.00)
@@ -484,6 +494,25 @@ mod tests {
             cost_of_call("gpt-5.6-terra", None, u),
             cost_of_call("gpt-5.6", None, u),
         );
+    }
+
+    /// A point release must not resolve to its major version. Prefix matching
+    /// makes that failure silent and expensive: `claude-opus-4-5-...` matching
+    /// `claude-opus-4` bills at 3x the real rate, and nothing about the result
+    /// looks wrong.
+    #[test]
+    fn dated_point_releases_resolve_to_the_point_release() {
+        for (id, expected) in [
+            ("claude-opus-4-5-20251101", "claude-opus-4-5"),
+            ("claude-opus-4.5", "claude-opus-4.5"),
+            ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5"),
+            ("claude-haiku-4-5-20251001", "claude-haiku-4-5"),
+            ("claude-opus-4-20250514", "claude-opus-4"),
+            ("claude-sonnet-4-20250514", "claude-sonnet-4"),
+        ] {
+            let got = price_of(id).map(|mc| mc.name);
+            assert_eq!(got, Some(expected), "{id} resolved to {got:?}");
+        }
     }
 
     /// The premium re-prices the entire request, and a prompt exactly at the

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -502,13 +502,18 @@ impl BatchClient {
         }
     }
 
-    /// Wait for a batch to complete.
-    pub async fn wait_for_batch(&self, batch_id: &str) -> Result<Batch, WaitForBatchError> {
+    /// Wait for a batch to complete, calling `on_progress` after every status poll.
+    pub async fn wait_for_batch(
+        &self,
+        batch_id: &str,
+        mut on_progress: impl FnMut(&Batch),
+    ) -> Result<Batch, WaitForBatchError> {
         let mut attempts = 0;
         let mut seconds_waited = 0;
 
         loop {
             let batch = self.get_batch_status(batch_id).await?;
+            on_progress(&batch);
 
             match batch.status {
                 BatchStatus::Completed => return Ok(batch),

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -508,7 +508,6 @@ impl BatchClient {
         batch_id: &str,
         mut on_progress: impl FnMut(&Batch),
     ) -> Result<Batch, WaitForBatchError> {
-        let mut attempts = 0;
         let mut seconds_waited = 0;
 
         loop {
@@ -530,14 +529,12 @@ impl BatchClient {
                     return Err(WaitForBatchError::BatchCancelled(batch_id.to_string()))
                 }
                 BatchStatus::InProgress | BatchStatus::Validating | BatchStatus::Finalizing => {
-                    attempts += 1;
                     // Still in progress, wait and try again
                     if seconds_waited >= 86400 {
                         return Err(WaitForBatchError::BatchTimeout(batch_id.to_string()));
                     }
 
-                    // Exponential backoff with a cap
-                    let delay = std::cmp::min(120, 2_u64.pow(attempts)) as u64;
+                    let delay = 5;
                     info!(
                         "batch {} is still in progress, waiting {} seconds",
                         batch_id, delay

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -84,8 +84,8 @@ pub struct ChatClient {
     /// hitting the API. Useful for testing or offline usage.
     pub cached_only: bool,
 
-    /// Clients whose caches are checked, in order, before this client's cache. These clients
-    /// are never allowed to make API requests through this client.
+    /// Clients whose caches are checked in order after this client's cache. These clients are
+    /// never allowed to make API requests through this client. Configure them newest-to-oldest.
     cache_fallbacks: Vec<ChatClient>,
 }
 
@@ -847,12 +847,12 @@ impl ChatClient {
         }
     }
 
-    /// Check another client's cache before this client's cache, without ever allowing the
-    /// fallback client to make an API request.
+    /// Check another client's cache after this client's cache, without ever allowing the
+    /// fallback client to make an API request. Add multiple fallbacks newest-to-oldest.
     ///
     /// This is useful when migrating models: configure the new model as `self`, then add the
-    /// old model as a cache fallback. Requests reuse valid old-model responses when available,
-    /// otherwise reuse this client's cache, and only then call this client's API.
+    /// old model as a cache fallback. Requests reuse this client's cache first, then valid
+    /// old-model responses, and only then call this client's API.
     /// Multiple fallbacks are checked in the order they are added.
     pub fn with_cache_fallback(mut self, fallback: ChatClient) -> Self {
         self.cache_fallbacks.push(fallback);
@@ -1143,6 +1143,22 @@ impl ChatClient {
             map_response(chat_response).map(|mapped_response| (mapped_response, response.usage))
         };
 
+        if let Some(cached_response) = self
+            .chat_cached(&chat_request, process_result.clone())
+            .await
+        {
+            match cached_response {
+                Ok((result, _usage)) => {
+                    debug!("Using cached response from current model {}", self.model);
+                    return Ok(result);
+                }
+                Err(error) => warn!(
+                    "Ignoring invalid cached response from current model {}: {}",
+                    self.model, error
+                ),
+            }
+        }
+
         for fallback in &self.cache_fallbacks {
             let fallback_request = ChatRequest {
                 model: fallback.model.clone(),
@@ -1176,44 +1192,34 @@ impl ChatClient {
             }
         }
 
-        let chat_response = if let Some(cached_response) = self
-            .chat_cached(&chat_request, process_result.clone())
-            .await
+        if self.cached_only {
+            return Err(ChatError::CacheMiss);
+        }
+        let chat_response = self.chat_uncached(&chat_request).await?;
+        let (result, usage) = process_result(chat_response.clone())?;
+        *self.usage.write().unwrap() += usage;
+
+        // cache the response
         {
-            debug!("Using cached response");
-            let (result, _usage) = cached_response?;
-            result
-        } else {
-            if self.cached_only {
-                return Err(ChatError::CacheMiss);
+            let chat_request_cache_key = chat_request.cache_key();
+            let chat_request = serde_json::to_string(&chat_request)
+                .map_err(|e| ChatError::JsonSerializeError(e, chat_request.clone()))?;
+
+            if let Some(cache_directory) = &self.cache_directory {
+                // Compress the response with zstd before writing to disk
+                let compressed = zstd::encode_all(chat_response.as_bytes(), 3)?;
+                crate::cache::write_to_cache_dir(
+                    cache_directory,
+                    &chat_request_cache_key,
+                    &compressed,
+                )
+                .await?;
             }
-            let chat_response = self.chat_uncached(&chat_request).await?;
-            let (result, usage) = process_result(chat_response.clone())?;
-            *self.usage.write().unwrap() += usage;
 
-            // cache the response
-            {
-                let chat_request_cache_key = chat_request.cache_key();
-                let chat_request = serde_json::to_string(&chat_request)
-                    .map_err(|e| ChatError::JsonSerializeError(e, chat_request.clone()))?;
+            self.lru.insert(chat_request, chat_response);
+        }
 
-                if let Some(cache_directory) = &self.cache_directory {
-                    // Compress the response with zstd before writing to disk
-                    let compressed = zstd::encode_all(chat_response.as_bytes(), 3)?;
-                    crate::cache::write_to_cache_dir(
-                        cache_directory,
-                        &chat_request_cache_key,
-                        &compressed,
-                    )
-                    .await?;
-                }
-
-                self.lru.insert(chat_request, chat_response.clone());
-            }
-            result
-        };
-
-        Ok(chat_response)
+        Ok(result)
     }
 
     /// Send chat messages to the batch API and deserialize the responses into the given type.
@@ -1361,8 +1367,9 @@ impl ChatClient {
         &self,
         request: &ChatRequest,
     ) -> Option<Result<String, IndividualChatError>> {
-        let mut clients = self.cache_fallbacks.iter().collect::<Vec<_>>();
-        clients.push(self);
+        let clients = std::iter::once(self)
+            .chain(self.cache_fallbacks.iter())
+            .collect::<Vec<_>>();
 
         for client in clients {
             let candidate = ChatRequest {

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -19,7 +19,7 @@ use crate::batch::{BatchResponseItem, BatchStatus};
 use crate::schema::OpenAiTransform;
 use crate::utils::{api_key, OpenAiApiKeyError};
 use crate::OpenAiError;
-use log::{debug, info};
+use log::{debug, info, warn};
 
 /// To use this library, you need to create a [`ChatClient`]. This contains various information needed to interact with the ChatGPT API,
 /// such as the API key, the model to use, and the URL of the API.
@@ -83,6 +83,10 @@ pub struct ChatClient {
     /// If true, all uncached requests will fail with [`ChatError::CacheMiss`] instead of
     /// hitting the API. Useful for testing or offline usage.
     pub cached_only: bool,
+
+    /// Clients whose caches are checked, in order, before this client's cache. These clients
+    /// are never allowed to make API requests through this client.
+    cache_fallbacks: Vec<ChatClient>,
 }
 
 /// The role of a message.
@@ -755,6 +759,7 @@ impl ChatClient {
             semaphore: Semaphore::new(100),
             http_client: crate::utils::pooled_client(),
             cached_only: false,
+            cache_fallbacks: Vec::new(),
         }
     }
 
@@ -832,6 +837,18 @@ impl ChatClient {
             cached_only: true,
             ..self
         }
+    }
+
+    /// Check another client's cache before this client's cache, without ever allowing the
+    /// fallback client to make an API request.
+    ///
+    /// This is useful when migrating models: configure the new model as `self`, then add the
+    /// old model as a cache fallback. Requests reuse valid old-model responses when available,
+    /// otherwise reuse this client's cache, and only then call this client's API.
+    /// Multiple fallbacks are checked in the order they are added.
+    pub fn with_cache_fallback(mut self, fallback: ChatClient) -> Self {
+        self.cache_fallbacks.push(fallback);
+        self
     }
 
     /// Sets the base URL
@@ -1117,6 +1134,39 @@ impl ChatClient {
 
             map_response(chat_response).map(|mapped_response| (mapped_response, response.usage))
         };
+
+        for fallback in &self.cache_fallbacks {
+            let fallback_request = ChatRequest {
+                model: fallback.model.clone(),
+                messages: chat_request.messages.clone(),
+                response_format: chat_request.response_format.clone(),
+                service_tier: fallback.service_tier.clone(),
+                prompt_cache_key: fallback.prompt_cache_key.clone(),
+                reasoning_effort: fallback.reasoning_effort.clone(),
+                extra_body: fallback.extra_body.clone(),
+            };
+
+            if let Some(cached_response) = fallback
+                .chat_cached(&fallback_request, process_result.clone())
+                .await
+            {
+                match cached_response {
+                    Ok((result, _usage)) => {
+                        debug!(
+                            "Using cached response from fallback model {}",
+                            fallback.model
+                        );
+                        return Ok(result);
+                    }
+                    Err(error) => {
+                        warn!(
+                            "Ignoring invalid cached response from fallback model {}: {}",
+                            fallback.model, error
+                        );
+                    }
+                }
+            }
+        }
 
         let chat_response = if let Some(cached_response) = self
             .chat_cached(&chat_request, process_result.clone())
@@ -1829,4 +1879,16 @@ async fn gemini_audio_transcription() {
         "Expected 'stale smell of old beer' in transcription, got: {}",
         result.text
     );
+}
+
+#[cfg(test)]
+#[test]
+fn cache_fallbacks_preserve_insertion_order() {
+    let client = ChatClient::new("unused", "new-model")
+        .with_cache_fallback(ChatClient::new("unused", "oldest-model"))
+        .with_cache_fallback(ChatClient::new("unused", "newer-model"));
+
+    assert_eq!(client.cache_fallbacks.len(), 2);
+    assert_eq!(client.cache_fallbacks[0].model, "oldest-model");
+    assert_eq!(client.cache_fallbacks[1].model, "newer-model");
 }

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -662,6 +662,10 @@ pub enum ChatError {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum BatchChatError {
+    /// One or more requests missed every configured cache while cached-only mode was enabled.
+    #[error("Cache miss: {0} batch request(s) were not found in cache")]
+    CacheMiss(usize),
+
     /// An error occurred when uploading the file to the API.
     #[error("Error uploading file")]
     FileUploadError(#[from] crate::files::FilesError),
@@ -707,6 +711,10 @@ pub enum BatchChatError {
     /// An error occurred when listing the batches.
     #[error("Error listing batches")]
     ListBatchesError(#[from] crate::batch::ListBatchesError),
+
+    /// IO error while persisting a successful batch response in the local cache.
+    #[error("IO error while writing batch response cache")]
+    CacheIoError(#[from] std::io::Error),
 }
 
 /// Errors that can occur when sending many chat requests via the batch API.
@@ -1218,6 +1226,22 @@ impl ChatClient {
         self.batch_chat_with_system_prompt("", prompts).await
     }
 
+    /// Send objects through the Batch API using `prompt` to render each object, returning
+    /// every original object paired with its result. This is the chat equivalent of
+    /// [`crate::embeddings::EmbeddingsClient::embed_fn`].
+    pub async fn batch_chat_fn<'a, I, S, T>(
+        &self,
+        items: &'a [I],
+        prompt: impl Fn(&'a I) -> S,
+    ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
+    where
+        S: Into<String>,
+        T: DeserializeOwned + JsonSchema,
+    {
+        self.batch_chat_with_system_prompt_fn("", items, prompt)
+            .await
+    }
+
     /// Send a batch of chat messages to the API and deserialize the responses into the given type.
     /// The first argument, the system prompt, is used to tell the AI how to behave during the conversations.
     ///
@@ -1241,6 +1265,25 @@ impl ChatClient {
             .collect();
 
         self.batch_chat_with_messages(prompts).await
+    }
+
+    /// Send objects through the Batch API with a shared system prompt, returning every
+    /// original object paired with its result.
+    pub async fn batch_chat_with_system_prompt_fn<'a, I, S, T>(
+        &self,
+        system_prompt: impl Into<String> + Clone,
+        items: &'a [I],
+        prompt: impl Fn(&'a I) -> S,
+    ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
+    where
+        S: Into<String>,
+        T: DeserializeOwned + JsonSchema,
+    {
+        let prompts = items.iter().map(&prompt).collect::<Vec<_>>();
+        let results = self
+            .batch_chat_with_system_prompt(system_prompt, prompts)
+            .await?;
+        Ok(items.iter().zip(results).collect())
     }
 
     /// Send a batch of sequences of chat messages to the API and deserialize the responses into the given type.
@@ -1283,6 +1326,100 @@ impl ChatClient {
         Ok(chat_responses)
     }
 
+    /// Send objects through the Batch API using `messages` to build each conversation,
+    /// returning every original object paired with its result.
+    pub async fn batch_chat_with_messages_fn<'a, I, T>(
+        &self,
+        items: &'a [I],
+        messages: impl Fn(&'a I) -> Vec<ChatMessage>,
+    ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
+    where
+        T: DeserializeOwned + JsonSchema,
+    {
+        let messages = items.iter().map(messages).collect();
+        let results = self.batch_chat_with_messages(messages).await?;
+        Ok(items.iter().zip(results).collect())
+    }
+
+    fn request_for_messages(
+        &self,
+        messages: Vec<ChatMessage>,
+        response_format: ResponseFormat,
+    ) -> ChatRequest {
+        ChatRequest {
+            model: self.model.clone(),
+            messages,
+            response_format,
+            service_tier: self.service_tier.clone(),
+            prompt_cache_key: self.prompt_cache_key.clone(),
+            reasoning_effort: self.reasoning_effort.clone(),
+            extra_body: self.extra_body.clone(),
+        }
+    }
+
+    async fn cached_batch_content(
+        &self,
+        request: &ChatRequest,
+    ) -> Option<Result<String, IndividualChatError>> {
+        let mut clients = self.cache_fallbacks.iter().collect::<Vec<_>>();
+        clients.push(self);
+
+        for client in clients {
+            let candidate = ChatRequest {
+                model: client.model.clone(),
+                messages: request.messages.clone(),
+                response_format: request.response_format.clone(),
+                service_tier: client.service_tier.clone(),
+                prompt_cache_key: client.prompt_cache_key.clone(),
+                reasoning_effort: client.reasoning_effort.clone(),
+                extra_body: client.extra_body.clone(),
+            };
+            let Some(Ok(raw)) = client.chat_cached(&candidate, Ok).await else {
+                continue;
+            };
+            let Ok(response) = serde_json::from_str::<ChatResponseOrError>(&raw) else {
+                warn!(
+                    "Ignoring malformed cached batch response for {}",
+                    client.model
+                );
+                continue;
+            };
+            match response {
+                ChatResponseOrError::Response(response) => {
+                    let Some(choice) = response.choices.into_iter().next() else {
+                        continue;
+                    };
+                    return Some(
+                        choice
+                            .message
+                            .content()
+                            .map_err(IndividualChatError::Refusal),
+                    );
+                }
+                ChatResponseOrError::Error(_) => continue,
+            }
+        }
+        None
+    }
+
+    async fn cache_batch_response(
+        &self,
+        request: &ChatRequest,
+        response: &ChatResponse,
+    ) -> Result<(), std::io::Error> {
+        let raw = serde_json::to_string(response).expect("ChatResponse is serializable");
+        if let Some(cache_directory) = &self.cache_directory {
+            let compressed = zstd::encode_all(raw.as_bytes(), 3)?;
+            crate::cache::write_to_cache_dir(cache_directory, &request.cache_key(), &compressed)
+                .await?;
+        }
+        self.lru.insert(
+            serde_json::to_string(request).expect("ChatRequest is serializable"),
+            raw,
+        );
+        Ok(())
+    }
+
     /// Send a batch of sequences of chat messages to the API. It's called "chat_with_messages_raw" because it allows you to specify any response format, and doesn't attempt to deserialize the chat completion.
     ///
     /// This goes through the batch API, which is cheaper and has higher ratelimits, but is much higher-latency. The responses to the batch API stick around in OpenAI's servers for some time, and before starting a new batch request, `tysm` will automatically check if that same request has been made before (and reuse it if so).
@@ -1294,37 +1431,54 @@ impl ChatClient {
 
         info!("Starting batch chat with {} prompts", prompts.len());
 
+        let mut output = (0..prompts.len()).map(|_| None).collect::<Vec<_>>();
+        let mut misses = Vec::new();
+        for (index, (messages, response_format)) in prompts.into_iter().enumerate() {
+            let request = self.request_for_messages(messages, response_format);
+            if let Some(cached) = self.cached_batch_content(&request).await {
+                output[index] = Some(cached);
+            } else {
+                misses.push((index, request));
+            }
+        }
+
+        if misses.is_empty() {
+            return Ok(output.into_iter().map(Option::unwrap).collect());
+        }
+        if self.cached_only {
+            return Err(BatchChatError::CacheMiss(misses.len()));
+        }
+
         let batch_client = BatchClient::from(self);
 
-        let (custom_ids, requests) = prompts
+        let (indexed_custom_ids, requests) = misses
             .into_iter()
-            .map(|(messages, response_format)| {
-                let request_str = format!("{messages:?}, {response_format:?}, {:?}", self.model);
+            .map(|(index, request)| {
+                let request_str = serde_json::to_string(&request).unwrap();
                 let request_hash = const_xxh3(request_str.as_bytes());
                 let custom_id = format!("request-{}", request_hash);
                 (
-                    (custom_id.clone(), request_hash),
+                    (index, custom_id.clone(), request_hash),
                     (
                         request_hash,
-                        BatchRequestItem::new_chat(
-                            custom_id,
-                            ChatRequest {
-                                model: self.model.clone(),
-                                messages,
-                                response_format,
-                                service_tier: self.service_tier.clone(),
-                                prompt_cache_key: self.prompt_cache_key.clone(),
-                                reasoning_effort: self.reasoning_effort.clone(),
-                                extra_body: self.extra_body.clone(),
-                            },
+                        (
+                            request.clone(),
+                            BatchRequestItem::new_chat(custom_id, request),
                         ),
                     ),
                 )
             })
             .unzip::<_, _, Vec<_>, HashMap<_, _>>();
-        let requests = requests.values().cloned().collect::<Vec<_>>();
+        let requests_by_hash = requests;
+        let requests = requests_by_hash
+            .values()
+            .map(|(_, item)| item.clone())
+            .collect::<Vec<_>>();
 
-        let (custom_ids, hashes) = custom_ids.into_iter().unzip::<_, _, Vec<_>, HashSet<_>>();
+        let hashes = indexed_custom_ids
+            .iter()
+            .map(|(_, _, hash)| *hash)
+            .collect::<HashSet<_>>();
         let request_hash = hashes
             .into_iter()
             .fold(0, |acc: u64, hash: u64| acc.wrapping_add(hash));
@@ -1431,29 +1585,31 @@ impl ChatClient {
             }
         }
 
-        let results = custom_ids
-            .into_iter()
-            .map(|custom_id| {
-                results
-                    .get(&custom_id)
-                    .ok_or(BatchChatError::CustomIdNotFound(custom_id.clone()))
-                    .and_then(|response| {
-                        response
-                            .choices
-                            .first()
-                            .ok_or(BatchChatError::BatchNoChoices(custom_id))
-                    })
-                    .map(|choice| {
-                        choice
-                            .message
-                            .clone()
-                            .content()
-                            .map_err(IndividualChatError::Refusal)
-                    })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        for (hash, (request, _)) in &requests_by_hash {
+            let custom_id = format!("request-{hash}");
+            if let Some(response) = results.get(&custom_id) {
+                self.cache_batch_response(request, response).await?;
+            }
+        }
 
-        Ok(results)
+        for (index, custom_id, _) in indexed_custom_ids {
+            let response = results
+                .get(&custom_id)
+                .ok_or(BatchChatError::CustomIdNotFound(custom_id.clone()))?;
+            let choice = response
+                .choices
+                .first()
+                .ok_or(BatchChatError::BatchNoChoices(custom_id))?;
+            output[index] = Some(
+                choice
+                    .message
+                    .clone()
+                    .content()
+                    .map_err(IndividualChatError::Refusal),
+            );
+        }
+
+        Ok(output.into_iter().map(Option::unwrap).collect())
     }
 
     async fn chat_cached<T>(
@@ -1891,4 +2047,74 @@ fn cache_fallbacks_preserve_insertion_order() {
     assert_eq!(client.cache_fallbacks.len(), 2);
     assert_eq!(client.cache_fallbacks[0].model, "oldest-model");
     assert_eq!(client.cache_fallbacks[1].model, "newer-model");
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn batch_fn_pairs_objects_and_uses_fallback_cache_without_network() {
+    #[derive(Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, PartialEq)]
+    struct Answer {
+        value: String,
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let old_cache = temp.path().join("old");
+    let new_cache = temp.path().join("new");
+    std::fs::create_dir_all(&old_cache).unwrap();
+    std::fs::create_dir_all(&new_cache).unwrap();
+
+    let old = ChatClient::new("unused", "old-model").with_cache_directory(&old_cache);
+    let response_format = ResponseFormat::JsonSchema {
+        json_schema: JsonSchemaFormat::new::<Answer>(),
+    };
+    let request = old.request_for_messages(
+        vec![
+            ChatMessage::system("return a value"),
+            ChatMessage::user("alpha"),
+        ],
+        response_format,
+    );
+    old.cache_batch_response(
+        &request,
+        &ChatResponse {
+            id: "cached".into(),
+            object: "chat.completion".into(),
+            created: 0,
+            model: "old-model".into(),
+            system_fingerprint: None,
+            choices: vec![ChatChoice {
+                index: 0,
+                message: ChatMessageResponse {
+                    role: Role::Assistant,
+                    content: Some(r#"{"value":"cached answer"}"#.into()),
+                    refusal: None,
+                },
+                logprobs: None,
+                finish_reason: "stop".into(),
+            }],
+            usage: ChatUsage::default(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let client = ChatClient::new("unused", "new-model")
+        .with_cache_directory(&new_cache)
+        .with_cache_fallback(old)
+        .with_cached_only();
+    let items = vec!["alpha".to_string()];
+    let results = client
+        .batch_chat_with_system_prompt_fn::<_, _, Answer>("return a value", &items, |item| {
+            item.clone()
+        })
+        .await
+        .unwrap();
+
+    assert!(std::ptr::eq(results[0].0, &items[0]));
+    assert_eq!(
+        results[0].1.as_ref().unwrap(),
+        &Answer {
+            value: "cached answer".into()
+        }
+    );
 }

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -53,6 +53,16 @@ pub struct ChatClient {
     /// This client's token consumption via the Batch API (as reported by the API). Tracked
     /// separately from `usage` because OpenAI bills batch requests at 50% of the standard price.
     pub batch_usage: RwLock<ChatUsage>,
+    /// Dollars billed so far, accumulated one request at a time.
+    ///
+    /// Kept beside the token counters rather than derived from them because a
+    /// model's rate can depend on a single request's prompt size (see
+    /// [`crate::model_prices::LongContext`]) — pricing the summed tokens of
+    /// many short requests would bill them all at the long-context premium.
+    ///
+    /// `None` once any request used a model we have no price for, since the
+    /// total is unknowable from then on.
+    pub spend: RwLock<Option<f64>>,
     /// The directory in which to cache responses to requests
     pub cache_directory: Option<PathBuf>,
 
@@ -758,6 +768,7 @@ impl ChatClient {
             lru: DashMap::new(),
             usage: RwLock::new(ChatUsage::default()),
             batch_usage: RwLock::new(ChatUsage::default()),
+            spend: RwLock::new(Some(0.0)),
             cache_directory: None,
             backup_cache_directory: None,
             service_tier: None,
@@ -1198,6 +1209,7 @@ impl ChatClient {
         let chat_response = self.chat_uncached(&chat_request).await?;
         let (result, usage) = process_result(chat_response.clone())?;
         *self.usage.write().unwrap() += usage;
+        self.record_spend(self.service_tier.as_deref(), usage, 1.0);
 
         // cache the response
         {
@@ -1552,9 +1564,7 @@ impl ChatClient {
                 .await?
         };
 
-        let batch = batch_client
-            .wait_for_batch(&batch.id, on_progress)
-            .await?;
+        let batch = batch_client.wait_for_batch(&batch.id, on_progress).await?;
 
         let results = batch_client.get_batch_results(&batch).await?;
 
@@ -1601,6 +1611,10 @@ impl ChatClient {
             for response in results.values() {
                 *batch_usage += response.usage;
             }
+        }
+        for response in results.values() {
+            // Batch pricing is a flat 50% of the standard (non-tier) price.
+            self.record_spend(None, response.usage, 0.5);
         }
 
         for (hash, (request, _)) in &requests_by_hash {
@@ -1780,11 +1794,27 @@ impl ChatClient {
     /// and may be out of date or unavailable for the model you're using.
     /// If you notice the prices being out of date, [please leave an issue](https://github.com/not-pizza/tysm)!
     pub fn cost(&self) -> Option<f64> {
-        let live =
-            crate::model_prices::cost(&self.model, self.service_tier.as_deref(), self.usage())?;
-        // Batch pricing is a flat 50% of the standard (non-tier) price.
-        let batch = crate::model_prices::cost(&self.model, None, self.batch_usage())? / 2.0;
-        Some(live + batch)
+        *self.spend.read().unwrap()
+    }
+
+    /// Price one request and add it to the running total, `discount` scaling
+    /// the result (the Batch API bills at half).
+    ///
+    /// Priced here, per request, rather than by pricing the accumulated token
+    /// counts later: a model with a long-context premium charges by how large
+    /// one prompt was, which the totals no longer remember.
+    fn record_spend(&self, service_tier: Option<&str>, usage: ChatUsage, discount: f64) {
+        let mut spend = self.spend.write().unwrap();
+        match crate::model_prices::cost_of_call(&self.model, service_tier, usage) {
+            Some(dollars) => {
+                if let Some(total) = spend.as_mut() {
+                    *total += dollars * discount;
+                }
+            }
+            // One unpriced request makes the total unknowable, and it stays
+            // that way — a later priced request must not resurrect it.
+            None => *spend = None,
+        }
     }
 }
 
@@ -1829,14 +1859,66 @@ fn cost_includes_batch_usage_at_half_price() {
         completion_token_details: None,
     };
 
-    *client.usage.write().unwrap() = usage;
+    client.record_spend(None, usage, 1.0);
     let live_only = client.cost().unwrap();
 
-    *client.batch_usage.write().unwrap() = usage;
+    client.record_spend(None, usage, 0.5);
     let with_batch = client.cost().unwrap();
 
     // The same usage again via the Batch API should cost exactly half as much more.
     assert!((with_batch - live_only * 1.5).abs() < 1e-9);
+}
+
+#[test]
+fn an_unpriced_request_makes_the_total_unknowable() {
+    let client = ChatClient::new("sk-test", "some-model-we-have-no-price-for");
+    let usage = ChatUsage {
+        prompt_tokens: 1_000,
+        completion_tokens: 1_000,
+        total_tokens: 2_000,
+        prompt_token_details: None,
+        completion_token_details: None,
+    };
+
+    // A client that has done nothing has spent nothing, whatever its model.
+    assert_eq!(client.cost(), Some(0.0));
+
+    client.record_spend(None, usage, 1.0);
+    assert_eq!(client.cost(), None);
+}
+
+/// The client accumulates dollars, not tokens, so a long run of short requests
+/// is never mistaken for one long-context request.
+#[test]
+fn spend_accumulates_per_request_not_from_summed_tokens() {
+    let client = ChatClient::new("sk-test", "gpt-5.6-luna");
+    let short = ChatUsage {
+        prompt_tokens: 50_000,
+        completion_tokens: 0,
+        total_tokens: 50_000,
+        prompt_token_details: None,
+        completion_token_details: None,
+    };
+
+    // Six 50k requests sum to 300k tokens, past luna's 272k threshold — but
+    // each was billed on its own at the cheap card: 0.3M @ $0.20 = $0.06.
+    for _ in 0..6 {
+        client.record_spend(None, short, 1.0);
+    }
+    let spent = client.cost().unwrap();
+    assert!((spent - 0.06).abs() < 1e-9, "{spent}");
+
+    // Those same 300k tokens arriving as a single request cross the threshold
+    // and cost twice as much.
+    let one_long = ChatUsage {
+        prompt_tokens: 300_000,
+        total_tokens: 300_000,
+        ..short
+    };
+    let fresh = ChatClient::new("sk-test", "gpt-5.6-luna");
+    fresh.record_spend(None, one_long, 1.0);
+    let spent_at_once = fresh.cost().unwrap();
+    assert!((spent_at_once - 0.12).abs() < 1e-9, "{spent_at_once}");
 }
 
 #[test]

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -48,8 +48,11 @@ pub struct ChatClient {
     pub model: String,
     /// A cache of recent responses.
     pub lru: DashMap<String, String>,
-    /// This client's token consumption (as reported by the API). Batch requests will not affect `usage`.
+    /// This client's token consumption (as reported by the API). Batch API requests are tracked separately in `batch_usage`.
     pub usage: RwLock<ChatUsage>,
+    /// This client's token consumption via the Batch API (as reported by the API). Tracked
+    /// separately from `usage` because OpenAI bills batch requests at 50% of the standard price.
+    pub batch_usage: RwLock<ChatUsage>,
     /// The directory in which to cache responses to requests
     pub cache_directory: Option<PathBuf>,
 
@@ -742,6 +745,7 @@ impl ChatClient {
             model: model.into(),
             lru: DashMap::new(),
             usage: RwLock::new(ChatUsage::default()),
+            batch_usage: RwLock::new(ChatUsage::default()),
             cache_directory: None,
             backup_cache_directory: None,
             service_tier: None,
@@ -1367,6 +1371,16 @@ impl ChatClient {
             })
             .collect::<Result<HashMap<_, _>, BatchChatError>>()?;
 
+        // Each entry in `results` is one billed batch request; accumulate its reported
+        // usage. (A batch reattached from a previous run is counted again — the tokens
+        // were genuinely billed, just possibly already counted by the earlier process.)
+        {
+            let mut batch_usage = self.batch_usage.write().unwrap();
+            for response in results.values() {
+                *batch_usage += response.usage;
+            }
+        }
+
         let results = custom_ids
             .into_iter()
             .map(|custom_id| {
@@ -1521,22 +1535,32 @@ impl ChatClient {
         }
     }
 
-    /// Returns how many tokens have been used so far.
+    /// Returns how many tokens have been used so far, excluding Batch API requests
+    /// (see [`batch_usage`](Self::batch_usage)).
     ///
     /// Does not double-count tokens used in cached responses.
     pub fn usage(&self) -> ChatUsage {
         *self.usage.read().unwrap()
     }
 
-    /// Attempts to compute the cost in dollars of the usage of this client.
+    /// Returns how many tokens have been used via the Batch API so far.
+    pub fn batch_usage(&self) -> ChatUsage {
+        *self.batch_usage.read().unwrap()
+    }
+
+    /// Attempts to compute the cost in dollars of the usage of this client,
+    /// including Batch API usage at its 50% discount.
     ///
     /// This is provided on a best-effort basis. The prices are hardcoded into
     /// the library (as OpenAI doesn't provide an API to get API pricing info),
     /// and may be out of date or unavailable for the model you're using.
     /// If you notice the prices being out of date, [please leave an issue](https://github.com/not-pizza/tysm)!
     pub fn cost(&self) -> Option<f64> {
-        let usage = self.usage();
-        crate::model_prices::cost(&self.model, self.service_tier.as_deref(), usage)
+        let live =
+            crate::model_prices::cost(&self.model, self.service_tier.as_deref(), self.usage())?;
+        // Batch pricing is a flat 50% of the standard (non-tier) price.
+        let batch = crate::model_prices::cost(&self.model, None, self.batch_usage())? / 2.0;
+        Some(live + batch)
     }
 }
 
@@ -1568,6 +1592,27 @@ fn test_deser() {
 }
 "#;
     let _chat_response: ChatResponse = serde_json::from_str(s).unwrap();
+}
+
+#[test]
+fn cost_includes_batch_usage_at_half_price() {
+    let client = ChatClient::new("sk-test", "gpt-4o");
+    let usage = ChatUsage {
+        prompt_tokens: 1_000_000,
+        completion_tokens: 1_000_000,
+        total_tokens: 2_000_000,
+        prompt_token_details: None,
+        completion_token_details: None,
+    };
+
+    *client.usage.write().unwrap() = usage;
+    let live_only = client.cost().unwrap();
+
+    *client.batch_usage.write().unwrap() = usage;
+    let with_batch = client.cost().unwrap();
+
+    // The same usage again via the Batch API should cost exactly half as much more.
+    assert!((with_batch - live_only * 1.5).abs() < 1e-9);
 }
 
 #[test]

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -2125,3 +2125,65 @@ async fn batch_fn_pairs_objects_and_uses_fallback_cache_without_network() {
         }
     );
 }
+
+#[cfg(test)]
+#[tokio::test]
+async fn batch_prefers_current_model_cache_over_fallback_cache() {
+    #[derive(Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, PartialEq)]
+    struct Answer {
+        value: String,
+    }
+
+    async fn cache_answer(client: &ChatClient, value: &str) {
+        let request = client.request_for_messages(
+            vec![
+                ChatMessage::system("return a value"),
+                ChatMessage::user("alpha"),
+            ],
+            ResponseFormat::JsonSchema {
+                json_schema: JsonSchemaFormat::new::<Answer>(),
+            },
+        );
+        client
+            .cache_batch_response(
+                &request,
+                &ChatResponse {
+                    id: "cached".into(),
+                    object: "chat.completion".into(),
+                    created: 0,
+                    model: client.model.clone(),
+                    system_fingerprint: None,
+                    choices: vec![ChatChoice {
+                        index: 0,
+                        message: ChatMessageResponse {
+                            role: Role::Assistant,
+                            content: Some(format!(r#"{{"value":"{value}"}}"#)),
+                            refusal: None,
+                        },
+                        logprobs: None,
+                        finish_reason: "stop".into(),
+                    }],
+                    usage: ChatUsage::default(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let current = ChatClient::new("unused", "current-model")
+        .with_cache_directory(temp.path().join("current"));
+    let fallback = ChatClient::new("unused", "fallback-model")
+        .with_cache_directory(temp.path().join("fallback"));
+    cache_answer(&current, "current").await;
+    cache_answer(&fallback, "fallback").await;
+
+    let client = current.with_cache_fallback(fallback).with_cached_only();
+    let items = vec!["alpha".to_string()];
+    let results = client
+        .batch_chat_with_system_prompt_fn::<_, _, Answer>("return a value", &items, Clone::clone)
+        .await
+        .unwrap();
+
+    assert_eq!(results[0].1.as_ref().unwrap().value, "current");
+}

--- a/src/chat_completions.rs
+++ b/src/chat_completions.rs
@@ -1228,8 +1228,10 @@ impl ChatClient {
     pub async fn batch_chat<T: DeserializeOwned + JsonSchema>(
         &self,
         prompts: Vec<impl Into<String>>,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<Result<T, IndividualChatError>>, BatchChatError> {
-        self.batch_chat_with_system_prompt("", prompts).await
+        self.batch_chat_with_system_prompt("", prompts, on_progress)
+            .await
     }
 
     /// Send objects through the Batch API using `prompt` to render each object, returning
@@ -1239,12 +1241,13 @@ impl ChatClient {
         &self,
         items: &'a [I],
         prompt: impl Fn(&'a I) -> S,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
     where
         S: Into<String>,
         T: DeserializeOwned + JsonSchema,
     {
-        self.batch_chat_with_system_prompt_fn("", items, prompt)
+        self.batch_chat_with_system_prompt_fn("", items, prompt, on_progress)
             .await
     }
 
@@ -1256,6 +1259,7 @@ impl ChatClient {
         &self,
         system_prompt: impl Into<String> + Clone,
         prompts: Vec<impl Into<String>>,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<Result<T, IndividualChatError>>, BatchChatError> {
         let prompts = prompts
             .into_iter()
@@ -1270,7 +1274,7 @@ impl ChatClient {
             })
             .collect();
 
-        self.batch_chat_with_messages(prompts).await
+        self.batch_chat_with_messages(prompts, on_progress).await
     }
 
     /// Send objects through the Batch API with a shared system prompt, returning every
@@ -1280,6 +1284,7 @@ impl ChatClient {
         system_prompt: impl Into<String> + Clone,
         items: &'a [I],
         prompt: impl Fn(&'a I) -> S,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
     where
         S: Into<String>,
@@ -1287,7 +1292,7 @@ impl ChatClient {
     {
         let prompts = items.iter().map(&prompt).collect::<Vec<_>>();
         let results = self
-            .batch_chat_with_system_prompt(system_prompt, prompts)
+            .batch_chat_with_system_prompt(system_prompt, prompts, on_progress)
             .await?;
         Ok(items.iter().zip(results).collect())
     }
@@ -1299,6 +1304,7 @@ impl ChatClient {
     pub async fn batch_chat_with_messages<T: DeserializeOwned + JsonSchema>(
         &self,
         messages: Vec<Vec<ChatMessage>>,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<Result<T, IndividualChatError>>, BatchChatError> {
         let json_schema = JsonSchemaFormat::new::<T>();
 
@@ -1312,6 +1318,7 @@ impl ChatClient {
                     .into_iter()
                     .map(|m| (m, response_format.clone()))
                     .collect(),
+                on_progress,
             )
             .await?;
 
@@ -1338,12 +1345,13 @@ impl ChatClient {
         &self,
         items: &'a [I],
         messages: impl Fn(&'a I) -> Vec<ChatMessage>,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<(&'a I, Result<T, IndividualChatError>)>, BatchChatError>
     where
         T: DeserializeOwned + JsonSchema,
     {
         let messages = items.iter().map(messages).collect();
-        let results = self.batch_chat_with_messages(messages).await?;
+        let results = self.batch_chat_with_messages(messages, on_progress).await?;
         Ok(items.iter().zip(results).collect())
     }
 
@@ -1433,6 +1441,7 @@ impl ChatClient {
     pub async fn batch_chat_with_messages_raw(
         &self,
         prompts: Vec<(Vec<ChatMessage>, ResponseFormat)>,
+        on_progress: impl FnMut(&crate::batch::Batch),
     ) -> Result<Vec<Result<String, IndividualChatError>>, BatchChatError> {
         use crate::batch::{BatchClient, BatchRequestItem};
 
@@ -1543,7 +1552,9 @@ impl ChatClient {
                 .await?
         };
 
-        let batch = batch_client.wait_for_batch(&batch.id).await?;
+        let batch = batch_client
+            .wait_for_batch(&batch.id, on_progress)
+            .await?;
 
         let results = batch_client.get_batch_results(&batch).await?;
 
@@ -2111,9 +2122,12 @@ async fn batch_fn_pairs_objects_and_uses_fallback_cache_without_network() {
         .with_cached_only();
     let items = vec!["alpha".to_string()];
     let results = client
-        .batch_chat_with_system_prompt_fn::<_, _, Answer>("return a value", &items, |item| {
-            item.clone()
-        })
+        .batch_chat_with_system_prompt_fn::<_, _, Answer>(
+            "return a value",
+            &items,
+            |item| item.clone(),
+            |_| {},
+        )
         .await
         .unwrap();
 
@@ -2181,7 +2195,12 @@ async fn batch_prefers_current_model_cache_over_fallback_cache() {
     let client = current.with_cache_fallback(fallback).with_cached_only();
     let items = vec!["alpha".to_string()];
     let results = client
-        .batch_chat_with_system_prompt_fn::<_, _, Answer>("return a value", &items, Clone::clone)
+        .batch_chat_with_system_prompt_fn::<_, _, Answer>(
+            "return a value",
+            &items,
+            Clone::clone,
+            |_| {},
+        )
         .await
         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod cache;
 pub mod chat_completions;
 pub mod embeddings;
 pub mod files;
-mod model_prices;
+pub mod model_prices;
 mod schema;
 mod utils;
 

--- a/src/model_prices.rs
+++ b/src/model_prices.rs
@@ -1,652 +1,98 @@
-//! This module contains the pricing of different models.
+//! The pricing of different models.
+//!
+//! The table itself lives in the dependency-free [`model_prices`] crate, so
+//! that builds which only need to price tokens — Android/Soong among them —
+//! can vendor it without dragging this client's dependency tree along. This
+//! module is the thin layer that prices a [`ChatUsage`] with it.
 
-/// The cost of using a model, in dollars per million tokens.
-#[derive(Debug, Clone)]
-pub(crate) struct ModelCost {
-    pub(crate) name: &'static str,
-    /// The cost of input tokens, in dollars per million tokens.
-    pub(crate) input: f64,
-    /// The cost of cached input tokens, in dollars per million tokens.
-    pub(crate) cached_input: Option<f64>,
-    /// The cost of output tokens, in dollars per million tokens.
-    pub(crate) output: f64,
+pub use model_prices::{
+    price_of, CallTokens, LongContext, ModelCost, TierCost, MODELS, RATE_CARD_VERSION,
+};
+
+use crate::chat_completions::ChatUsage;
+
+/// The billable token counts of one request.
+///
+/// `completion_tokens` already includes any reasoning tokens, so
+/// `completion_token_details` is deliberately not added on top of it — that
+/// would charge reasoning twice.
+fn tokens_of(usage: ChatUsage) -> CallTokens {
+    CallTokens {
+        prompt: usage.prompt_tokens,
+        cached_prompt: usage
+            .prompt_token_details
+            .map_or(0, |details| details.cached_tokens),
+        output: usage.completion_tokens,
+    }
 }
 
-pub(crate) const CHAT_COMPLETIONS: &[ModelCost] = &[
-    // Anthropic
-    ModelCost {
-        name: "claude-opus-4.5",
-        input: 5.0,
-        cached_input: None,
-        output: 25.0,
-    },
-    ModelCost {
-        name: "claude-opus-4.1",
-        input: 15.0,
-        cached_input: None,
-        output: 75.0,
-    },
-    ModelCost {
-        name: "claude-opus-4",
-        input: 15.0,
-        cached_input: None,
-        output: 75.0,
-    },
-    ModelCost {
-        name: "claude-sonnet-4.5",
-        input: 3.0,
-        cached_input: None,
-        output: 15.0,
-    },
-    ModelCost {
-        name: "claude-sonnet-4",
-        input: 3.0,
-        cached_input: None,
-        output: 15.0,
-    },
-    ModelCost {
-        name: "claude-haiku-4",
-        input: 0.80,
-        cached_input: None,
-        output: 4.0,
-    },
-    ModelCost {
-        name: "claude-3-opus",
-        input: 15.0,
-        cached_input: None,
-        output: 75.0,
-    },
-    ModelCost {
-        name: "claude-3-7-sonnet",
-        input: 3.0,
-        cached_input: None,
-        output: 15.0,
-    },
-    ModelCost {
-        name: "claude-3-5-haiku",
-        input: 0.80,
-        cached_input: None,
-        output: 4.0,
-    },
-    // Anthropic (new models, copied from https://platform.claude.com/docs/en/about-claude/pricing on 2026-07-06)
-    ModelCost {
-        name: "claude-fable-5",
-        input: 10.0,
-        cached_input: None,
-        output: 50.0,
-    },
-    ModelCost {
-        name: "claude-mythos-5",
-        input: 10.0,
-        cached_input: None,
-        output: 50.0,
-    },
-    ModelCost {
-        name: "claude-opus-5",
-        input: 5.0,
-        cached_input: None,
-        output: 25.0,
-    },
-    ModelCost {
-        name: "claude-opus-4-8",
-        input: 5.0,
-        cached_input: None,
-        output: 25.0,
-    },
-    ModelCost {
-        name: "claude-opus-4-7",
-        input: 5.0,
-        cached_input: None,
-        output: 25.0,
-    },
-    ModelCost {
-        name: "claude-opus-4-6",
-        input: 5.0,
-        cached_input: None,
-        output: 25.0,
-    },
-    ModelCost {
-        name: "claude-sonnet-4-6",
-        input: 3.0,
-        cached_input: None,
-        output: 15.0,
-    },
-    // Introductory pricing through 2026-08-31; becomes 3.0/15.0 on 2026-09-01.
-    // https://platform.claude.com/docs/en/about-claude/pricing
-    ModelCost {
-        name: "claude-sonnet-5",
-        input: 2.0,
-        cached_input: None,
-        output: 10.0,
-    },
-    ModelCost {
-        name: "claude-haiku-4-5",
-        input: 1.0,
-        cached_input: None,
-        output: 5.0,
-    },
-    // OpenAI
-    // Copied from https://platform.openai.com/docs/pricing on 2026-03-17
-    ModelCost {
-        name: "gpt-4.1",
-        input: 2.00,
-        cached_input: Some(0.50),
-        output: 8.00,
-    },
-    ModelCost {
-        name: "gpt-4.1-mini",
-        input: 0.40,
-        cached_input: Some(0.10),
-        output: 1.60,
-    },
-    ModelCost {
-        name: "gpt-4.1-nano",
-        input: 0.10,
-        cached_input: Some(0.025),
-        output: 0.40,
-    },
-    ModelCost {
-        name: "gpt-4.5-preview",
-        input: 75.00,
-        cached_input: Some(37.50),
-        output: 150.00,
-    },
-    ModelCost {
-        name: "gpt-4o",
-        input: 2.50,
-        cached_input: Some(1.25),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-4o-audio-preview",
-        input: 2.50,
-        cached_input: None,
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-4o-realtime-preview",
-        input: 5.00,
-        cached_input: Some(2.50),
-        output: 20.00,
-    },
-    ModelCost {
-        name: "gpt-4o-mini",
-        input: 0.15,
-        cached_input: Some(0.075),
-        output: 0.60,
-    },
-    ModelCost {
-        name: "gpt-4o-mini-audio-preview",
-        input: 0.15,
-        cached_input: None,
-        output: 0.60,
-    },
-    ModelCost {
-        name: "gpt-4o-mini-realtime-preview",
-        input: 0.60,
-        cached_input: Some(0.30),
-        output: 2.40,
-    },
-    ModelCost {
-        name: "o1",
-        input: 15.00,
-        cached_input: Some(7.50),
-        output: 60.00,
-    },
-    ModelCost {
-        name: "o1-pro",
-        input: 150.00,
-        cached_input: None,
-        output: 600.00,
-    },
-    ModelCost {
-        name: "o3",
-        input: 2.00,
-        cached_input: Some(0.50),
-        output: 8.00,
-    },
-    ModelCost {
-        name: "o4-mini",
-        input: 1.10,
-        cached_input: Some(0.275),
-        output: 4.40,
-    },
-    ModelCost {
-        name: "o3-mini",
-        input: 1.10,
-        cached_input: Some(0.55),
-        output: 4.40,
-    },
-    ModelCost {
-        name: "o1-mini",
-        input: 1.10,
-        cached_input: Some(0.55),
-        output: 4.40,
-    },
-    ModelCost {
-        name: "gpt-4o-mini-search-preview",
-        input: 0.15,
-        cached_input: None,
-        output: 0.60,
-    },
-    ModelCost {
-        name: "gpt-4o-search-preview",
-        input: 2.50,
-        cached_input: None,
-        output: 10.00,
-    },
-    ModelCost {
-        name: "computer-use-preview",
-        input: 3.00,
-        cached_input: None,
-        output: 12.00,
-    },
-    // Google Gemini
-    ModelCost {
-        name: "gemini-3.1-pro",
-        input: 2.00,
-        cached_input: Some(0.20),
-        output: 12.00,
-    },
-    ModelCost {
-        name: "gemini-3-flash",
-        input: 0.50,
-        cached_input: Some(0.05),
-        output: 3.00,
-    },
-    ModelCost {
-        name: "gemini-3.1-flash-lite",
-        input: 0.25,
-        cached_input: Some(0.025),
-        output: 1.50,
-    },
-    ModelCost {
-        name: "gemini-3.5-flash",
-        input: 1.50,
-        cached_input: Some(0.15),
-        output: 9.00,
-    },
-    // Released 2026-07-21 (google blog: gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber)
-    ModelCost {
-        name: "gemini-3.6-flash",
-        input: 1.50,
-        cached_input: Some(0.15),
-        output: 7.50,
-    },
-    ModelCost {
-        name: "gemini-3.5-flash-lite",
-        input: 0.30,
-        cached_input: Some(0.03),
-        output: 2.50,
-    },
-    ModelCost {
-        name: "gemini-2.5-pro",
-        input: 1.25,
-        cached_input: Some(0.13),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gemini-2.5-flash",
-        input: 0.30,
-        cached_input: Some(0.03),
-        output: 2.50,
-    },
-    ModelCost {
-        name: "gemini-2.5-flash-lite",
-        input: 0.10,
-        cached_input: Some(0.01),
-        output: 0.40,
-    },
-    ModelCost {
-        name: "gemini-2.0-flash",
-        input: 0.15,
-        cached_input: None,
-        output: 0.60,
-    },
-    ModelCost {
-        name: "gemini-2.0-flash-lite",
-        input: 0.075,
-        cached_input: None,
-        output: 0.30,
-    },
-    // GPT-5 models
-    ModelCost {
-        // "gpt-5.6" alias routes to gpt-5.6-sol
-        name: "gpt-5.6",
-        input: 5.00,
-        cached_input: Some(0.50),
-        output: 30.00,
-    },
-    ModelCost {
-        name: "gpt-5.6-sol",
-        input: 5.00,
-        cached_input: Some(0.50),
-        output: 30.00,
-    },
-    // Cut 20% on 2026-07-30 (from 2.50/0.25/15.00); https://openai.com/pricing
-    ModelCost {
-        name: "gpt-5.6-terra",
-        input: 2.00,
-        cached_input: Some(0.20),
-        output: 12.00,
-    },
-    // Cut 80% on 2026-07-30 (from 1.00/0.10/6.00); https://openai.com/pricing
-    ModelCost {
-        name: "gpt-5.6-luna",
-        input: 0.20,
-        cached_input: Some(0.02),
-        output: 1.20,
-    },
-    ModelCost {
-        name: "gpt-5.5-pro",
-        input: 30.00,
-        cached_input: None,
-        output: 180.00,
-    },
-    ModelCost {
-        name: "gpt-5.5",
-        input: 5.00,
-        cached_input: Some(0.50),
-        output: 30.00,
-    },
-    ModelCost {
-        name: "gpt-5.4-pro",
-        input: 30.00,
-        cached_input: None,
-        output: 180.00,
-    },
-    ModelCost {
-        name: "gpt-5.4",
-        input: 2.50,
-        cached_input: Some(0.25),
-        output: 15.00,
-    },
-    ModelCost {
-        name: "gpt-5.4-mini",
-        input: 0.75,
-        cached_input: Some(0.075),
-        output: 4.50,
-    },
-    ModelCost {
-        name: "gpt-5.4-nano",
-        input: 0.20,
-        cached_input: Some(0.02),
-        output: 1.25,
-    },
-    ModelCost {
-        name: "gpt-5.2-chat-latest",
-        input: 1.75,
-        cached_input: Some(0.175),
-        output: 14.00,
-    },
-    ModelCost {
-        name: "gpt-5.2-pro",
-        input: 21.00,
-        cached_input: None,
-        output: 168.00,
-    },
-    ModelCost {
-        name: "gpt-5.2",
-        input: 1.75,
-        cached_input: Some(0.175),
-        output: 14.00,
-    },
-    ModelCost {
-        name: "gpt-5.1-chat-latest",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5.1-codex-max",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5.1-codex",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5.1",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5-chat-latest",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5-codex",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-    ModelCost {
-        name: "gpt-5-pro",
-        input: 15.00,
-        cached_input: None,
-        output: 120.00,
-    },
-    ModelCost {
-        name: "gpt-5-mini",
-        input: 0.25,
-        cached_input: Some(0.025),
-        output: 2.00,
-    },
-    ModelCost {
-        name: "gpt-5-nano",
-        input: 0.05,
-        cached_input: Some(0.005),
-        output: 0.40,
-    },
-    ModelCost {
-        name: "gpt-5",
-        input: 1.25,
-        cached_input: Some(0.125),
-        output: 10.00,
-    },
-];
-
-// Flex tier pricing (OpenAI)
-// Copied from https://platform.openai.com/docs/pricing on 2026-03-17
-pub(crate) const FLEX_PRICES: &[ModelCost] = &[
-    ModelCost {
-        name: "gpt-5.5",
-        input: 2.50,
-        cached_input: Some(0.25),
-        output: 15.00,
-    },
-    ModelCost {
-        name: "gpt-5.4",
-        input: 1.25,
-        cached_input: Some(0.13),
-        output: 7.50,
-    },
-    ModelCost {
-        name: "gpt-5.4-pro",
-        input: 15.00,
-        cached_input: None,
-        output: 90.00,
-    },
-    ModelCost {
-        name: "gpt-5.4-mini",
-        input: 0.375,
-        cached_input: Some(0.0375),
-        output: 2.25,
-    },
-    ModelCost {
-        name: "gpt-5.4-nano",
-        input: 0.10,
-        cached_input: Some(0.01),
-        output: 0.625,
-    },
-    ModelCost {
-        name: "gpt-5.2",
-        input: 0.875,
-        cached_input: Some(0.0875),
-        output: 7.00,
-    },
-    ModelCost {
-        name: "gpt-5.1",
-        input: 0.625,
-        cached_input: Some(0.0625),
-        output: 5.00,
-    },
-    ModelCost {
-        name: "gpt-5",
-        input: 0.625,
-        cached_input: Some(0.0625),
-        output: 5.00,
-    },
-    ModelCost {
-        name: "gpt-5-mini",
-        input: 0.125,
-        cached_input: Some(0.0125),
-        output: 1.00,
-    },
-    ModelCost {
-        name: "gpt-5-nano",
-        input: 0.025,
-        cached_input: Some(0.0025),
-        output: 0.20,
-    },
-    ModelCost {
-        name: "o3",
-        input: 1.00,
-        cached_input: Some(0.25),
-        output: 4.00,
-    },
-    ModelCost {
-        name: "o4-mini",
-        input: 0.55,
-        cached_input: Some(0.138),
-        output: 2.20,
-    },
-];
-
-// Priority tier pricing (OpenAI)
-// Copied from https://platform.openai.com/docs/pricing on 2026-03-17
-pub(crate) const PRIORITY_PRICES: &[ModelCost] = &[
-    ModelCost {
-        name: "gpt-5.5",
-        input: 12.50,
-        cached_input: Some(1.25),
-        output: 75.00,
-    },
-    ModelCost {
-        name: "gpt-5.4",
-        input: 5.00,
-        cached_input: Some(0.50),
-        output: 30.00,
-    },
-];
-
-fn lookup<'a>(table: &'a [ModelCost], model: &str) -> Option<&'a ModelCost> {
-    table
-        .iter()
-        .filter(|mc| model.starts_with(mc.name))
-        .max_by_key(|mc| mc.name.len())
+/// The cost in dollars of a **single** request.
+///
+/// Must be called once per request and the results summed. Summing the token
+/// counts of several requests and pricing the total gives a different — and
+/// wrong — answer for any model with a [`LongContext`] card, because the
+/// premium keys off one request's prompt size.
+///
+/// Returns `None` for a model we have no price for.
+pub fn cost_of_call(model: &str, service_tier: Option<&str>, usage: ChatUsage) -> Option<f64> {
+    model_prices::cost_of_call(model, service_tier, tokens_of(usage))
 }
 
-pub(crate) fn cost(
+/// As [`cost_of_call`], but keeping the input and output dollars apart — for
+/// callers that report the two separately rather than only the total.
+pub fn cost_of_call_split(
     model: &str,
     service_tier: Option<&str>,
-    usage: crate::chat_completions::ChatUsage,
-) -> Option<f64> {
-    let tier_table = match service_tier {
-        Some("flex") => Some(FLEX_PRICES),
-        Some("priority") => Some(PRIORITY_PRICES),
-        _ => None,
-    };
-    let model_cost = tier_table
-        .and_then(|t| lookup(t, model))
-        .or_else(|| lookup(CHAT_COMPLETIONS, model))?;
-
-    let (cached_prompt_tokens, uncached_prompt_tokens) =
-        if let Some(details) = usage.prompt_token_details {
-            (
-                details.cached_tokens,
-                usage.prompt_tokens - details.cached_tokens,
-            )
-        } else {
-            (0, usage.prompt_tokens)
-        };
-
-    let usage_cost = model_cost.input * uncached_prompt_tokens as f64 / 1_000_000.0
-        + model_cost.cached_input.unwrap_or(model_cost.input) * cached_prompt_tokens as f64
-            / 1_000_000.0
-        + model_cost.output * usage.completion_tokens as f64 / 1_000_000.0;
-    Some(usage_cost)
+    usage: ChatUsage,
+) -> Option<(f64, f64)> {
+    model_prices::cost_of_call_split(model, service_tier, tokens_of(usage))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chat_completions::PromptTokenDetails;
 
+    /// The table is tested in the `model-prices` crate; what needs covering
+    /// here is the translation, and above all that cached tokens reach it —
+    /// dropping them would quietly bill every cache hit at full price.
     #[test]
-    fn test_cost() {
-        let usage = crate::chat_completions::ChatUsage {
-            prompt_tokens: 2000000,
-            completion_tokens: 1000000,
-            prompt_token_details: Some(crate::chat_completions::PromptTokenDetails {
-                cached_tokens: 1000000,
+    fn chat_usage_translates_to_billable_tokens() {
+        let usage = ChatUsage {
+            prompt_tokens: 2_000_000,
+            completion_tokens: 1_000_000,
+            total_tokens: 3_000_000,
+            prompt_token_details: Some(PromptTokenDetails {
+                cached_tokens: 1_000_000,
             }),
             completion_token_details: None,
-            total_tokens: 2000000,
         };
-        let cost = cost("gpt-4o", None, usage);
-        // input: 2.50,
-        // cached_input: Some(1.25),
-        // output: 10.00,
-        assert_eq!(cost, Some(2.50 + 1.25 + 10.00));
+        assert_eq!(
+            tokens_of(usage),
+            CallTokens {
+                prompt: 2_000_000,
+                cached_prompt: 1_000_000,
+                output: 1_000_000,
+            }
+        );
+
+        // gpt-4o: 1M uncached @2.50 + 1M cached @1.25 + 1M output @10.00
+        assert_eq!(
+            cost_of_call("gpt-4o", None, usage),
+            Some(2.50 + 1.25 + 10.00)
+        );
     }
 
     #[test]
-    fn test_flex_cost() {
-        let usage = crate::chat_completions::ChatUsage {
-            prompt_tokens: 1000000,
-            completion_tokens: 1000000,
+    fn a_request_with_no_cache_details_bills_every_prompt_token_uncached() {
+        let usage = ChatUsage {
+            prompt_tokens: 1_000_000,
+            completion_tokens: 0,
+            total_tokens: 1_000_000,
             prompt_token_details: None,
             completion_token_details: None,
-            total_tokens: 2000000,
         };
-        // gpt-5.4 flex: input 1.25, output 7.50
-        let c = cost("gpt-5.4", Some("flex"), usage);
-        assert_eq!(c, Some(1.25 + 7.50));
-    }
-
-    #[test]
-    fn test_priority_cost() {
-        let usage = crate::chat_completions::ChatUsage {
-            prompt_tokens: 1000000,
-            completion_tokens: 1000000,
-            prompt_token_details: None,
-            completion_token_details: None,
-            total_tokens: 2000000,
-        };
-        // gpt-5.4 priority: input 5.00, output 30.00
-        let c = cost("gpt-5.4", Some("priority"), usage);
-        assert_eq!(c, Some(5.00 + 30.00));
-    }
-
-    #[test]
-    fn test_tier_falls_back_to_standard() {
-        let usage = crate::chat_completions::ChatUsage {
-            prompt_tokens: 1000000,
-            completion_tokens: 1000000,
-            prompt_token_details: None,
-            completion_token_details: None,
-            total_tokens: 2000000,
-        };
-        // gpt-4o has no flex pricing, should fall back to standard
-        let standard = cost("gpt-4o", None, usage);
-        let flex = cost("gpt-4o", Some("flex"), usage);
-        assert_eq!(standard, flex);
+        assert_eq!(tokens_of(usage).cached_prompt, 0);
+        assert_eq!(cost_of_call("gpt-4o", None, usage), Some(2.50));
     }
 }


### PR DESCRIPTION
Batch API responses report `usage` in each item's body, but `batch_chat_*` discarded it, so batch spend was invisible to `usage()`/`cost()` (the `usage` field doc even said so).

- New `ChatClient::batch_usage: RwLock<ChatUsage>` accumulates the reported usage of every billed batch item, kept separate from `usage` because OpenAI bills the Batch API at a flat 50% of the standard price.
- `cost()` now returns live cost + batch cost × 0.5 (batch priced against the standard table, not a service tier).
- New `batch_usage()` accessor, and a unit test asserting the half-price combination.

One caveat noted in a comment: a batch reattached from a previous run (the existing request-hash reuse path) counts its usage again in the new process — the tokens were genuinely billed, just possibly already counted by the earlier process.

The 5 failing `tests::*` lib tests fail identically on main (they hit the network); the new test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbNrXGx3ddWwHTsBNur2w9